### PR TITLE
DHH-62: Lägg till SRD-repo som extern källa

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "External/daggerheart-srd"]
+	path = External/daggerheart-srd
+	url = https://github.com/seansbox/daggerheart-srd

--- a/External/README.md
+++ b/External/README.md
@@ -1,0 +1,15 @@
+# External Dependencies
+
+Denna mapp innehåller externa kodkällor som versioneras separat.
+
+## daggerheart-srd
+- Plats: `External/daggerheart-srd`
+- Typ: git submodule
+- Upstream: `https://github.com/seansbox/daggerheart-srd`
+
+Initiera submodules efter clone:
+
+```bash
+git submodule update --init --recursive
+```
+


### PR DESCRIPTION
## Jira
- Epic: DHH-61
- Task: DHH-62

## What this PR does
- Lägger till git submodule-konfiguration för `External/daggerheart-srd`
- Lägger till dokumentation i `External/README.md`

## Files
- `.gitmodules`
- `External/README.md`
- `External/daggerheart-srd` (git submodule pointer)

## Notes
- Detta är första steget i SRD-integrationen. Parserarbete sker i DHH-63.