### PR TITLE
Epic/dhh 15 infrastructure

### DIFF
--- a/Daggerheart-Helper.Web/Daggerheart-Helper.Web.csproj
+++ b/Daggerheart-Helper.Web/Daggerheart-Helper.Web.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Daggerheart-Helper.Shared\Daggerheart-Helper.Shared.csproj"/>
+        <ProjectReference Include="..\Infrastructure\Infrastructure.csproj" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.14.0"/>

--- a/Daggerheart-Helper.Web/Program.cs
+++ b/Daggerheart-Helper.Web/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.FluentUI.AspNetCore.Components;
 using Daggerheart_Helper.Web.Components;
+using Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -7,6 +8,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 builder.Services.AddFluentUIComponents();
+builder.Services.AddDaggerheartPersistence(builder.Configuration.GetConnectionString("DefaultConnection")!);
 
 var app = builder.Build();
 

--- a/Daggerheart-Helper.slnx
+++ b/Daggerheart-Helper.slnx
@@ -2,5 +2,6 @@
   <Project Path="Core/Core.csproj" />
   <Project Path="Daggerheart-Helper.Shared/Daggerheart-Helper.Shared.csproj" />
   <Project Path="Daggerheart-Helper.Web/Daggerheart-Helper.Web.csproj" />
+  <Project Path="Infrastructure/Infrastructure.csproj" />
   <Project Path="Daggerheart-Helper/Daggerheart-Helper.csproj" />
 </Solution>

--- a/Infrastructure/DependencyInjection.cs
+++ b/Infrastructure/DependencyInjection.cs
@@ -1,0 +1,15 @@
+using Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddDaggerheartPersistence(this IServiceCollection services, string connectionString)
+    {
+        services.AddDbContext<DaggerheartDbContext>(options => options.UseSqlite(connectionString));
+        return services;
+    }
+}
+

--- a/Infrastructure/Infrastructure.csproj
+++ b/Infrastructure/Infrastructure.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>Infrastructure</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.11">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.11" />
+  </ItemGroup>
+
+</Project>
+

--- a/Infrastructure/Persistence/DaggerheartDbContext.cs
+++ b/Infrastructure/Persistence/DaggerheartDbContext.cs
@@ -1,0 +1,299 @@
+using Core.Entities;
+using Core.Value_Objects;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.Persistence;
+
+public class DaggerheartDbContext : DbContext
+{
+    public DaggerheartDbContext(DbContextOptions<DaggerheartDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Ability> Abilities => Set<Ability>();
+    public DbSet<Armor> Armors => Set<Armor>();
+    public DbSet<Character> Characters => Set<Character>();
+    public DbSet<Feature> Features => Set<Feature>();
+    public DbSet<FeatureEffect> FeatureEffects => Set<FeatureEffect>();
+    public DbSet<GameClass> GameClasses => Set<GameClass>();
+    public DbSet<Subclass> Subclasses => Set<Subclass>();
+    public DbSet<Weapon> Weapons => Set<Weapon>();
+
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+    {
+        configurationBuilder.Properties<Enum>().HaveConversion<string>();
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<Ability>(entity =>
+        {
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.Title).IsRequired().HasMaxLength(200);
+            entity.Property(x => x.FeatureDescription).IsRequired();
+            entity.HasIndex(x => new { x.Domain, x.Level });
+        });
+
+        modelBuilder.Entity<Armor>(entity =>
+        {
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.Name).IsRequired().HasMaxLength(200);
+            entity.Property(x => x.ArmorScore).IsRequired();
+            entity.OwnsOne(x => x.DamageThresholds, owned =>
+            {
+                owned.Property(x => x.Minor).HasColumnName("MinorThreshold");
+                owned.Property(x => x.Major).HasColumnName("MajorThreshold");
+                owned.Property(x => x.Severe).HasColumnName("SevereThreshold");
+            });
+            entity.HasMany(x => x.Features)
+                .WithMany(x => x.Armors)
+                .UsingEntity<Dictionary<string, object>>(
+                    "ArmorFeatures",
+                    right => right
+                        .HasOne<Feature>()
+                        .WithMany()
+                        .HasForeignKey("FeatureId")
+                        .OnDelete(DeleteBehavior.Cascade),
+                    left => left
+                        .HasOne<Armor>()
+                        .WithMany()
+                        .HasForeignKey("ArmorId")
+                        .OnDelete(DeleteBehavior.Cascade),
+                    join =>
+                    {
+                        join.HasKey("ArmorId", "FeatureId");
+                        join.ToTable("ArmorFeatures");
+                    });
+        });
+
+        modelBuilder.Entity<Character>(entity =>
+        {
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.Name).IsRequired().HasMaxLength(200);
+            entity.Property(x => x.Level).HasDefaultValue(1);
+            entity.Ignore(x => x.Proficiency);
+
+            entity.OwnsOne(x => x.Traits, owned =>
+            {
+                owned.Property(x => x.Agility).HasColumnName(nameof(TraitScores.Agility));
+                owned.Property(x => x.Strength).HasColumnName(nameof(TraitScores.Strength));
+                owned.Property(x => x.Finesse).HasColumnName(nameof(TraitScores.Finesse));
+                owned.Property(x => x.Instinct).HasColumnName(nameof(TraitScores.Instinct));
+                owned.Property(x => x.Presence).HasColumnName(nameof(TraitScores.Presence));
+                owned.Property(x => x.Knowledge).HasColumnName(nameof(TraitScores.Knowledge));
+            });
+
+            entity.OwnsOne(x => x.DamageThresholds, owned =>
+            {
+                owned.Property(x => x.Minor).HasColumnName("DamageThresholdMinor");
+                owned.Property(x => x.Major).HasColumnName("DamageThresholdMajor");
+                owned.Property(x => x.Severe).HasColumnName("DamageThresholdSevere");
+            });
+
+            entity.OwnsOne(x => x.HitPoints, owned =>
+            {
+                owned.Property(x => x.Current).HasColumnName("HitPointsCurrent");
+                owned.Property(x => x.Max).HasColumnName("HitPointsMax");
+            });
+
+            entity.OwnsOne(x => x.Stress, owned =>
+            {
+                owned.Property(x => x.Current).HasColumnName("StressCurrent");
+                owned.Property(x => x.Max).HasColumnName("StressMax");
+            });
+
+            entity.OwnsOne(x => x.Hope, owned =>
+            {
+                owned.Property(x => x.Current).HasColumnName("HopeCurrent");
+                owned.Property(x => x.Max).HasColumnName("HopeMax");
+            });
+
+            entity.OwnsOne(x => x.ArmorSlots, owned =>
+            {
+                owned.Property(x => x.Current).HasColumnName("ArmorSlotsCurrent");
+                owned.Property(x => x.Max).HasColumnName("ArmorSlotsMax");
+            });
+
+            entity.HasOne(x => x.GameClass)
+                .WithMany()
+                .HasForeignKey(x => x.GameClassId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            entity.HasOne(x => x.Subclass)
+                .WithMany()
+                .HasForeignKey(x => x.SubclassId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            entity.HasOne(x => x.Multiclass)
+                .WithMany()
+                .HasForeignKey(x => x.MulticlassId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            entity.HasOne(x => x.MulticlassSubclass)
+                .WithMany()
+                .HasForeignKey(x => x.MulticlassSubclassId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            entity.HasOne(x => x.EquippedArmor)
+                .WithMany()
+                .HasForeignKey(x => x.EquippedArmorId)
+                .OnDelete(DeleteBehavior.SetNull);
+
+            entity.HasOne(x => x.PrimaryWeapon)
+                .WithMany()
+                .HasForeignKey(x => x.PrimaryWeaponId)
+                .OnDelete(DeleteBehavior.SetNull);
+
+            entity.HasOne(x => x.SecondaryWeapon)
+                .WithMany()
+                .HasForeignKey(x => x.SecondaryWeaponId)
+                .OnDelete(DeleteBehavior.SetNull);
+        });
+
+        modelBuilder.Entity<Feature>(entity =>
+        {
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.Name).IsRequired().HasMaxLength(200);
+            entity.Property(x => x.Description).IsRequired();
+
+            entity.HasMany(x => x.FeatureEffects)
+                .WithOne(x => x.Feature)
+                .HasForeignKey(x => x.FeatureId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<FeatureEffect>(entity =>
+        {
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.Condition).HasMaxLength(200);
+            entity.Property(x => x.Description).HasMaxLength(1000);
+
+            entity.HasIndex(x => x.FeatureId);
+            entity.HasIndex(x => new { x.EffectType, x.Target });
+
+            entity.ToTable(table =>
+            {
+                table.HasCheckConstraint(
+                    "CK_FeatureEffects_TraitTargetRequiresTraitType",
+                    "\"Target\" <> 'Trait' OR \"TraitType\" IS NOT NULL");
+            });
+        });
+
+        modelBuilder.Entity<GameClass>(entity =>
+        {
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.Name).IsRequired().HasMaxLength(200);
+            entity.Property(x => x.Description).IsRequired();
+            entity.OwnsOne(x => x.SuggestedTraits, owned =>
+            {
+                owned.Property(x => x.Agility).HasColumnName($"{nameof(GameClass.SuggestedTraits)}_{nameof(TraitScores.Agility)}");
+                owned.Property(x => x.Strength).HasColumnName($"{nameof(GameClass.SuggestedTraits)}_{nameof(TraitScores.Strength)}");
+                owned.Property(x => x.Finesse).HasColumnName($"{nameof(GameClass.SuggestedTraits)}_{nameof(TraitScores.Finesse)}");
+                owned.Property(x => x.Instinct).HasColumnName($"{nameof(GameClass.SuggestedTraits)}_{nameof(TraitScores.Instinct)}");
+                owned.Property(x => x.Presence).HasColumnName($"{nameof(GameClass.SuggestedTraits)}_{nameof(TraitScores.Presence)}");
+                owned.Property(x => x.Knowledge).HasColumnName($"{nameof(GameClass.SuggestedTraits)}_{nameof(TraitScores.Knowledge)}");
+            });
+            entity.OwnsOne(x => x.StartingThresholds, owned =>
+            {
+                owned.Property(x => x.Minor).HasColumnName($"{nameof(GameClass.StartingThresholds)}_{nameof(DamageThresholds.Minor)}");
+                owned.Property(x => x.Major).HasColumnName($"{nameof(GameClass.StartingThresholds)}_{nameof(DamageThresholds.Major)}");
+                owned.Property(x => x.Severe).HasColumnName($"{nameof(GameClass.StartingThresholds)}_{nameof(DamageThresholds.Severe)}");
+            });
+            entity.HasMany(x => x.Subclasses)
+                .WithOne(x => x.GameClass)
+                .HasForeignKey(x => x.GameClassId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.HasMany(x => x.Features)
+                .WithMany(x => x.GameClasses)
+                .UsingEntity<Dictionary<string, object>>(
+                    "GameClassFeatures",
+                    right => right
+                        .HasOne<Feature>()
+                        .WithMany()
+                        .HasForeignKey("FeatureId")
+                        .OnDelete(DeleteBehavior.Cascade),
+                    left => left
+                        .HasOne<GameClass>()
+                        .WithMany()
+                        .HasForeignKey("GameClassId")
+                        .OnDelete(DeleteBehavior.Cascade),
+                    join =>
+                    {
+                        join.HasKey("GameClassId", "FeatureId");
+                        join.ToTable("GameClassFeatures");
+                    });
+        });
+
+        modelBuilder.Entity<Subclass>(entity =>
+        {
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.Name).IsRequired().HasMaxLength(200);
+            entity.Property(x => x.Description).IsRequired();
+            entity.HasOne(x => x.GameClass)
+                .WithMany(x => x.Subclasses)
+                .HasForeignKey(x => x.GameClassId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.HasMany(x => x.Features)
+                .WithMany(x => x.Subclasses)
+                .UsingEntity<Dictionary<string, object>>(
+                    "SubclassFeatures",
+                    right => right
+                        .HasOne<Feature>()
+                        .WithMany()
+                        .HasForeignKey("FeatureId")
+                        .OnDelete(DeleteBehavior.Cascade),
+                    left => left
+                        .HasOne<Subclass>()
+                        .WithMany()
+                        .HasForeignKey("SubclassId")
+                        .OnDelete(DeleteBehavior.Cascade),
+                    join =>
+                    {
+                        join.HasKey("SubclassId", "FeatureId");
+                        join.ToTable("SubclassFeatures");
+                    });
+        });
+
+
+        modelBuilder.Entity<Weapon>(entity =>
+        {
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.Name).IsRequired().HasMaxLength(200);
+            entity.Property(x => x.Description).IsRequired();
+            entity.OwnsOne(x => x.Damage, damage =>
+            {
+                damage.Property(x => x.Bonus).HasColumnName("DamageBonus");
+                damage.Property(x => x.Type).HasColumnName("DamageType");
+                damage.OwnsOne(x => x.Dice, dice =>
+                {
+                    dice.Property(x => x.NumberOfDice).HasColumnName("DamageDiceCount");
+                    dice.Property(x => x.NumberOfSides).HasColumnName("DamageDiceSides");
+                });
+            });
+            entity.HasMany(x => x.Features)
+                .WithMany(x => x.Weapons)
+                .UsingEntity<Dictionary<string, object>>(
+                    "WeaponFeatures",
+                    right => right
+                        .HasOne<Feature>()
+                        .WithMany()
+                        .HasForeignKey("FeatureId")
+                        .OnDelete(DeleteBehavior.Cascade),
+                    left => left
+                        .HasOne<Weapon>()
+                        .WithMany()
+                        .HasForeignKey("WeaponId")
+                        .OnDelete(DeleteBehavior.Cascade),
+                    join =>
+                    {
+                        join.HasKey("WeaponId", "FeatureId");
+                        join.ToTable("WeaponFeatures");
+                    });
+        });
+    }
+}
+
+
+

--- a/Infrastructure/Persistence/DaggerheartDbContextFactory.cs
+++ b/Infrastructure/Persistence/DaggerheartDbContextFactory.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace Infrastructure.Persistence;
+
+public class DaggerheartDbContextFactory : IDesignTimeDbContextFactory<DaggerheartDbContext>
+{
+    public DaggerheartDbContext CreateDbContext(string[] args)
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DAGGERHEART_DB")
+            ?? "Data Source=daggerheart.db";
+
+        var optionsBuilder = new DbContextOptionsBuilder<DaggerheartDbContext>();
+        optionsBuilder.UseSqlite(connectionString);
+
+        return new DaggerheartDbContext(optionsBuilder.Options);
+    }
+}
+


### PR DESCRIPTION
This pull request introduces a new `Infrastructure` project to the solution, providing a persistence layer using Entity Framework Core with a SQLite backend. The main focus is on setting up the database context, dependency injection, and integrating this infrastructure into the web application.

**Infrastructure and Persistence Layer Integration:**

* Added a new `Infrastructure` project (`Infrastructure/Infrastructure.csproj`) targeting .NET 9, referencing the `Core` project, and including necessary EF Core packages for SQLite support.
* Implemented the `DaggerheartDbContext` class in `Infrastructure.Persistence` to define the database schema, entity relationships, and custom configurations for all major domain entities (e.g., `Ability`, `Armor`, `Character`, `Feature`, `GameClass`, `Subclass`, `Weapon`).
* Added a design-time factory (`DaggerheartDbContextFactory`) to support EF Core tooling and migrations, reading the connection string from an environment variable or defaulting to a local SQLite file.
* Provided a static extension method (`AddDaggerheartPersistence`) for registering the `DaggerheartDbContext` with dependency injection, using the supplied connection string.

**Web Application Integration:**

* Registered the new `Infrastructure` project as a reference in the web project (`Daggerheart-Helper.Web.csproj`) and updated the solution file to include it. [[1]](diffhunk://#diff-b4b755d087437798873d880b206c942d8870c6695d1d7ead77820fba2fd625c8R11) [[2]](diffhunk://#diff-92a052de7bb50e4467425897b6ef883aea76a343f9aa6726f9878c2b3b9338c2R5)
* Modified the web application's startup (`Program.cs`) to add the persistence layer using the connection string from configuration.