### PR TITLE
M5: SRD ingestion test suite

### DIFF
--- a/Daggerheart-Helper.Tests/Daggerheart-Helper.Tests.csproj
+++ b/Daggerheart-Helper.Tests/Daggerheart-Helper.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>DaggerheartHelper.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Srd.Ingestion\Srd.Ingestion.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="Srd.Ingestion.Tests\TestData\**\*" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>
+

--- a/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/Loading/SrdJsonLoaderTests.cs
+++ b/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/Loading/SrdJsonLoaderTests.cs
@@ -6,7 +6,7 @@ namespace DaggerheartHelper.Tests.Srd.Ingestion.Tests.Loading;
 public class SrdJsonLoaderTests
 {
     [Fact]
-    public async Task LoadAsync_ParsesKnownEntriesFromRealSRDFiles()
+    public async Task LoadAsync_ParsesKnownEntries()
     {
         var loader = new SrdJsonLoader();
         var catalog = await loader.LoadAsync(TestRepoPaths.SrdJsonDirectory);
@@ -35,6 +35,22 @@ public class SrdJsonLoaderTests
         Assert.Equal(1, runeWard.Level);
         Assert.Equal(0, runeWard.RecallCost);
         Assert.Equal(Core.Enums.AbilityType.Spell, runeWard.Type);
+    }
+
+    [Fact]
+    public async Task LoadAsync_ParsesKnownEntriesFromExternalSrd_WhenPresent()
+    {
+        if (!TestRepoPaths.HasExternalSrdJson)
+        {
+            return;
+        }
+
+        var loader = new SrdJsonLoader();
+        var catalog = await loader.LoadAsync(TestRepoPaths.SrdJsonDirectory);
+
+        Assert.NotEmpty(catalog.Armors);
+        Assert.NotEmpty(catalog.Weapons);
+        Assert.NotEmpty(catalog.Abilities);
     }
 }
 

--- a/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/Loading/SrdJsonLoaderTests.cs
+++ b/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/Loading/SrdJsonLoaderTests.cs
@@ -1,0 +1,41 @@
+using Srd.Ingestion.Loading;
+using Xunit;
+
+namespace DaggerheartHelper.Tests.Srd.Ingestion.Tests.Loading;
+
+public class SrdJsonLoaderTests
+{
+    [Fact]
+    public async Task LoadAsync_ParsesKnownEntriesFromRealSRDFiles()
+    {
+        var loader = new SrdJsonLoader();
+        var catalog = await loader.LoadAsync(TestRepoPaths.SrdJsonDirectory);
+
+        Assert.NotEmpty(catalog.Armors);
+        Assert.NotEmpty(catalog.Weapons);
+        Assert.NotEmpty(catalog.Abilities);
+
+        var gambeson = Assert.Single(catalog.Armors, x => x.Name == "Gambeson Armor");
+        Assert.Equal(1, gambeson.Tier);
+        Assert.Equal(3, gambeson.ArmorScore);
+        Assert.Equal(new Core.ValueObjects.DamageThresholds(5, 11), gambeson.DamageThresholds);
+        Assert.Single(gambeson.Features);
+        Assert.Equal("Flexible", gambeson.Features[0].Name);
+
+        var broadsword = Assert.Single(catalog.Weapons, x => x.Name == "Broadsword");
+        Assert.Equal(1, broadsword.Tier);
+        Assert.Equal(Core.Enums.Burden.OneHanded, broadsword.Burden);
+        Assert.Equal(Core.Enums.WeaponPriority.Primary, broadsword.Priority);
+        Assert.Equal(Core.Enums.TraitType.Agility, broadsword.Trait);
+        Assert.Equal(Core.Enums.Range.Melee, broadsword.Range);
+        Assert.Equal(new Core.ValueObjects.Damage(new Core.ValueObjects.Dice(1, 8), 0, Core.Enums.DamageType.Physical), broadsword.Damage);
+
+        var runeWard = Assert.Single(catalog.Abilities, x => x.Name == "Rune Ward");
+        Assert.Equal(Core.Enums.Domain.Arcana, runeWard.Domain);
+        Assert.Equal(1, runeWard.Level);
+        Assert.Equal(0, runeWard.RecallCost);
+        Assert.Equal(Core.Enums.AbilityType.Spell, runeWard.Type);
+    }
+}
+
+

--- a/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/Mapping/SrdEntityMapperTests.cs
+++ b/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/Mapping/SrdEntityMapperTests.cs
@@ -1,0 +1,47 @@
+using Core.Enums;
+using Srd.Ingestion.Domain;
+using Srd.Ingestion.Mapping;
+using Xunit;
+
+namespace DaggerheartHelper.Tests.Srd.Ingestion.Tests.Mapping;
+
+public class SrdEntityMapperTests
+{
+    [Fact]
+    public void ToEntity_MapsArmorCardToArmorEntity()
+    {
+        var card = new ArmorCard(
+            "Gambeson Armor",
+            1,
+            3,
+            new Core.ValueObjects.DamageThresholds(5, 11),
+            [new FeatureBlock("Flexible", "+1 to Evasion")]);
+
+        var entity = card.ToEntity();
+
+        Assert.Equal("Gambeson Armor", entity.Name);
+        Assert.Equal(Tier.Tier1, entity.Tier);
+        Assert.Equal(3, entity.ArmorScore);
+        Assert.Equal(new Core.ValueObjects.DamageThresholds(5, 11), entity.DamageThresholds);
+        Assert.Single(entity.Features);
+        Assert.Equal("Flexible", entity.Features[0].Name);
+    }
+
+    [Fact]
+    public void ToEntity_MapsAbilityCardToAbilityEntity()
+    {
+        var card = new AbilityCard("Rune Ward", Domain.Arcana, 1, 0, AbilityType.Spell, "Text");
+
+        var entity = card.ToEntity();
+
+        Assert.Equal("Rune Ward", entity.Title);
+        Assert.Equal(Domain.Arcana, entity.Domain);
+        Assert.Equal(1, entity.Level);
+        Assert.Equal(0, entity.RecallCost);
+        Assert.Equal(AbilityType.Spell, entity.Type);
+        Assert.Equal("Text", entity.FeatureDescription);
+    }
+}
+
+
+

--- a/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/Parsing/SrdParsersTests.cs
+++ b/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/Parsing/SrdParsersTests.cs
@@ -1,0 +1,70 @@
+using Core.Enums;
+using Core.ValueObjects;
+using Srd.Ingestion.Parsing;
+using Srd.Ingestion.Raw;
+using Xunit;
+using Range = Core.Enums.Range;
+
+namespace DaggerheartHelper.Tests.Srd.Ingestion.Tests.Parsing;
+
+public class SrdParsersTests
+{
+    [Theory]
+    [InlineData("1", 1)]
+    [InlineData(" 4 ", 4)]
+    public void ParseInt_ReturnsExpectedValue(string value, int expected)
+    {
+        var result = SrdParsers.ParseInt(value, "field");
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ParseThresholds_ReturnsMajorAndSevereValues()
+    {
+        var result = SrdParsers.ParseThresholds("5 / 11");
+
+        Assert.Equal(new DamageThresholds(5, 11), result);
+    }
+
+    [Fact]
+    public void ParseDamage_ReturnsDiceBonusAndKind()
+    {
+        var result = SrdParsers.ParseDamage("d10+3 phy");
+
+        Assert.Equal(new Damage(new Dice(1, 10), 3, DamageType.Physical), result);
+    }
+
+    [Theory]
+    [InlineData("One-Handed", Burden.OneHanded)]
+    [InlineData("Two-Handed", Burden.TwoHanded)]
+    public void ParseBurden_ReturnsExpectedEnumValue(string value, Burden expected)
+    {
+        Assert.Equal(expected, SrdParsers.ParseBurden(value));
+    }
+
+    [Theory]
+    [InlineData("Melee", Range.Melee)]
+    [InlineData("Very Close", Range.VeryClose)]
+    [InlineData("Close", Range.Close)]
+    [InlineData("Far", Range.Far)]
+    [InlineData("Very Far", Range.VeryFar)]
+    public void ParseRange_ReturnsExpectedEnumValue(string value, Range expected)
+    {
+        Assert.Equal(expected, SrdParsers.ParseRange(value));
+    }
+
+    [Fact]
+    public void ParseFeatures_TrimsAndPreservesQuestion()
+    {
+        var features = SrdParsers.ParseFeatures(
+            [
+                new RawFeatureDto { Name = " Flexible ", Text = " +1 to Evasion ", Question = "Why? " }
+            ]);
+
+        Assert.Single(features);
+        Assert.Equal(new global::Srd.Ingestion.Domain.FeatureBlock("Flexible", "+1 to Evasion", "Why?"), features[0]);
+    }
+}
+
+

--- a/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/TestData/Json/abilities.json
+++ b/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/TestData/Json/abilities.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "Rune Ward",
+    "domain": "Arcana",
+    "level": "1",
+    "recall": "0",
+    "type": "Spell",
+    "text": "Ward text"
+  }
+]
+

--- a/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/TestData/Json/armor.json
+++ b/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/TestData/Json/armor.json
@@ -1,0 +1,15 @@
+[
+  {
+    "base_score": "3",
+    "base_thresholds": "5 / 11",
+    "feature": [
+      {
+        "name": "Flexible",
+        "text": "+1 to Evasion"
+      }
+    ],
+    "name": "Gambeson Armor",
+    "tier": "1"
+  }
+]
+

--- a/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/TestData/Json/weapons.json
+++ b/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/TestData/Json/weapons.json
@@ -1,0 +1,13 @@
+[
+  {
+    "name": "Broadsword",
+    "tier": "1",
+    "burden": "One-Handed",
+    "damage": "d8 phy",
+    "trait": "Agility",
+    "range": "Melee",
+    "primary_or_secondary": "Primary",
+    "physical_or_magical": "Physical"
+  }
+]
+

--- a/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/TestRepoPaths.cs
+++ b/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/TestRepoPaths.cs
@@ -4,18 +4,24 @@ internal static class TestRepoPaths
 {
     private const string SentinelPath = "External/daggerheart-srd/.build/03_json/armor.json";
 
-    public static string RepositoryRoot => FindRepositoryRoot();
+    public static string LocalSrdJsonDirectory => Path.Combine(AppContext.BaseDirectory, "Srd.Ingestion.Tests", "TestData", "Json");
 
-    public static string SrdJsonDirectory => Path.Combine(RepositoryRoot, "External", "daggerheart-srd", ".build", "03_json");
+    public static string SrdJsonDirectory =>
+        TryFindRepositoryRoot(out var root)
+            ? Path.Combine(root, "External", "daggerheart-srd", ".build", "03_json")
+            : LocalSrdJsonDirectory;
 
-    private static string FindRepositoryRoot()
+    public static bool HasExternalSrdJson => TryFindRepositoryRoot(out _);
+
+    private static bool TryFindRepositoryRoot(out string root)
     {
         var current = new DirectoryInfo(AppContext.BaseDirectory);
         while (current is not null)
         {
             if (File.Exists(Path.Combine(current.FullName, SentinelPath)))
             {
-                return current.FullName;
+                root = current.FullName;
+                return true;
             }
 
             current = current.Parent;
@@ -25,10 +31,12 @@ internal static class TestRepoPaths
         var siblingRoot = FindSiblingWorktreeRoot();
         if (siblingRoot is not null)
         {
-            return siblingRoot;
+            root = siblingRoot;
+            return true;
         }
 
-        throw new DirectoryNotFoundException($"Could not locate repository root containing '{SentinelPath}'.");
+        root = string.Empty;
+        return false;
     }
 
     private static string? FindSiblingWorktreeRoot()

--- a/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/TestRepoPaths.cs
+++ b/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/TestRepoPaths.cs
@@ -1,0 +1,58 @@
+namespace DaggerheartHelper.Tests.Srd.Ingestion.Tests;
+
+internal static class TestRepoPaths
+{
+    private const string SentinelPath = "External/daggerheart-srd/.build/03_json/armor.json";
+
+    public static string RepositoryRoot => FindRepositoryRoot();
+
+    public static string SrdJsonDirectory => Path.Combine(RepositoryRoot, "External", "daggerheart-srd", ".build", "03_json");
+
+    private static string FindRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, SentinelPath)))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        // In git worktree setups, SRD build artifacts may exist in a sibling worktree root.
+        var siblingRoot = FindSiblingWorktreeRoot();
+        if (siblingRoot is not null)
+        {
+            return siblingRoot;
+        }
+
+        throw new DirectoryNotFoundException($"Could not locate repository root containing '{SentinelPath}'.");
+    }
+
+    private static string? FindSiblingWorktreeRoot()
+    {
+        var workspacesParent = new DirectoryInfo(AppContext.BaseDirectory);
+        while (workspacesParent is not null && workspacesParent.Name != "RiderProjects")
+        {
+            workspacesParent = workspacesParent.Parent;
+        }
+
+        if (workspacesParent is null)
+        {
+            return null;
+        }
+
+        foreach (var directory in workspacesParent.EnumerateDirectories("Daggerheart-Helper*"))
+        {
+            if (File.Exists(Path.Combine(directory.FullName, SentinelPath)))
+            {
+                return directory.FullName;
+            }
+        }
+
+        return null;
+    }
+}
+

--- a/Daggerheart-Helper.slnx
+++ b/Daggerheart-Helper.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Project Path="Core/Core.csproj" />
   <Project Path="Daggerheart-Helper.Shared/Daggerheart-Helper.Shared.csproj" />
+  <Project Path="Daggerheart-Helper.Tests/Daggerheart-Helper.Tests.csproj" />
   <Project Path="Daggerheart-Helper.Web/Daggerheart-Helper.Web.csproj" />
   <Project Path="Infrastructure/Infrastructure.csproj" />
   <Project Path="Daggerheart-Helper/Daggerheart-Helper.csproj" />


### PR DESCRIPTION
## Scope
- add Daggerheart-Helper.Tests project
- add parser, loader, and mapper tests for Srd.Ingestion
- add local SRD JSON fixtures so loader tests pass without submodule checkout
- keep optional coverage against external SRD data when submodule/build artifacts are present
## Issues
- Closes #87
- Relates to #88
- Relates to #89
- Relates to #90
## Validation
- dotnet test Daggerheart-Helper.slnx --verbosity normal
