### PR TITLE
refactor(core) - Clearer naming of Enums

### DIFF
--- a/Core/Entities/Weapon.cs
+++ b/Core/Entities/Weapon.cs
@@ -1,6 +1,5 @@
 using Core.Enums;
 using Core.ValueObjects;
-using Range = Core.Enums.Range;
 
 namespace Core.Entities;
 
@@ -12,7 +11,7 @@ public class Weapon
     public TraitType Trait { get; set; }
     public required Damage Damage { get; set; }
     public Burden Burden { get; set; }
-    public Range Range { get; set; }
+    public RangeType RangeType { get; set; }
     public WeaponPriority Category { get; set; }
     public List<Feature> Features { get; set; } = new();
     public Tier Tier { get; set; }

--- a/Core/Enums/RangeType.cs
+++ b/Core/Enums/RangeType.cs
@@ -1,6 +1,6 @@
 namespace Core.Enums;
 
-public enum Range
+public enum RangeType
 {
     Melee,
     VeryClose,

--- a/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/Loading/SrdJsonLoaderTests.cs
+++ b/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/Loading/SrdJsonLoaderTests.cs
@@ -27,11 +27,11 @@ public class SrdJsonLoaderTests
         Assert.Equal(Core.Enums.Burden.OneHanded, broadsword.Burden);
         Assert.Equal(Core.Enums.WeaponPriority.Primary, broadsword.Priority);
         Assert.Equal(Core.Enums.TraitType.Agility, broadsword.Trait);
-        Assert.Equal(Core.Enums.Range.Melee, broadsword.Range);
+        Assert.Equal(Core.Enums.RangeType.Melee, broadsword.RangeType);
         Assert.Equal(new Core.ValueObjects.Damage(new Core.ValueObjects.Dice(1, 8), 0, Core.Enums.DamageType.Physical), broadsword.Damage);
 
         var runeWard = Assert.Single(catalog.Abilities, x => x.Name == "Rune Ward");
-        Assert.Equal(Core.Enums.Domain.Arcana, runeWard.Domain);
+        Assert.Equal(Core.Enums.DomainType.Arcana, runeWard.Domain);
         Assert.Equal(1, runeWard.Level);
         Assert.Equal(0, runeWard.RecallCost);
         Assert.Equal(Core.Enums.AbilityType.Spell, runeWard.Type);

--- a/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/Mapping/SrdEntityMapperTests.cs
+++ b/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/Mapping/SrdEntityMapperTests.cs
@@ -30,12 +30,12 @@ public class SrdEntityMapperTests
     [Fact]
     public void ToEntity_MapsAbilityCardToAbilityEntity()
     {
-        var card = new AbilityCard("Rune Ward", Domain.Arcana, 1, 0, AbilityType.Spell, "Text");
+        var card = new AbilityCard("Rune Ward", DomainType.Arcana, 1, 0, AbilityType.Spell, "Text");
 
         var entity = card.ToEntity();
 
         Assert.Equal("Rune Ward", entity.Title);
-        Assert.Equal(Domain.Arcana, entity.Domain);
+        Assert.Equal(DomainType.Arcana, entity.DomainType);
         Assert.Equal(1, entity.Level);
         Assert.Equal(0, entity.RecallCost);
         Assert.Equal(AbilityType.Spell, entity.Type);

--- a/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/Parsing/SrdParsersTests.cs
+++ b/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/Parsing/SrdParsersTests.cs
@@ -3,7 +3,6 @@ using Core.ValueObjects;
 using Srd.Ingestion.Parsing;
 using Srd.Ingestion.Raw;
 using Xunit;
-using Range = Core.Enums.Range;
 
 namespace DaggerheartHelper.Tests.Srd.Ingestion.Tests.Parsing;
 
@@ -44,12 +43,12 @@ public class SrdParsersTests
     }
 
     [Theory]
-    [InlineData("Melee", Range.Melee)]
-    [InlineData("Very Close", Range.VeryClose)]
-    [InlineData("Close", Range.Close)]
-    [InlineData("Far", Range.Far)]
-    [InlineData("Very Far", Range.VeryFar)]
-    public void ParseRange_ReturnsExpectedEnumValue(string value, Range expected)
+    [InlineData("Melee", RangeType.Melee)]
+    [InlineData("Very Close", RangeType.VeryClose)]
+    [InlineData("Close", RangeType.Close)]
+    [InlineData("Far", RangeType.Far)]
+    [InlineData("Very Far", RangeType.VeryFar)]
+    public void ParseRange_ReturnsExpectedEnumValue(string value, RangeType expected)
     {
         Assert.Equal(expected, SrdParsers.ParseRange(value));
     }

--- a/Srd.Ingestion/Domain/AbilityCard.cs
+++ b/Srd.Ingestion/Domain/AbilityCard.cs
@@ -1,11 +1,10 @@
 using Core.Enums;
-using DomainEnum = Core.Enums.Domain;
 
 namespace Srd.Ingestion.Domain;
 
 public sealed record AbilityCard(
     string Name,
-    DomainEnum Domain,
+    DomainType Domain,
     int Level,
     int RecallCost,
     AbilityType Type,

--- a/Srd.Ingestion/Domain/WeaponCard.cs
+++ b/Srd.Ingestion/Domain/WeaponCard.cs
@@ -1,6 +1,5 @@
 using Core.Enums;
 using Core.ValueObjects;
-using Range = Core.Enums.Range;
 
 namespace Srd.Ingestion.Domain;
 
@@ -10,7 +9,7 @@ public sealed record WeaponCard(
     Burden Burden,
     WeaponPriority Priority,
     TraitType Trait,
-    Range Range,
+    RangeType RangeType,
     DamageType DamageKind,
     Damage Damage,
     IReadOnlyList<FeatureBlock> Features);

--- a/Srd.Ingestion/Mapping/SrdEntityMapper.cs
+++ b/Srd.Ingestion/Mapping/SrdEntityMapper.cs
@@ -26,7 +26,7 @@ public static class SrdEntityMapper
             Tier = ParseTier(card.Tier),
             Trait = card.Trait,
             Burden = card.Burden,
-            Range = card.Range,
+            RangeType = card.RangeType,
             Category = card.Priority,
             Damage = card.Damage,
             Description = string.Empty,
@@ -39,7 +39,7 @@ public static class SrdEntityMapper
         return new Ability
         {
             Title = card.Name,
-            Domain = card.Domain,
+            DomainType = card.Domain,
             Level = card.Level,
             RecallCost = card.RecallCost,
             Type = card.Type,

--- a/Srd.Ingestion/Parsing/SrdParsers.cs
+++ b/Srd.Ingestion/Parsing/SrdParsers.cs
@@ -3,8 +3,6 @@ using Core.Enums;
 using Srd.Ingestion.Domain;
 using Srd.Ingestion.Raw;
 using Core.ValueObjects;
-using Range = Core.Enums.Range;
-using DomainEnum = Core.Enums.Domain;
 
 namespace Srd.Ingestion.Parsing;
 
@@ -81,13 +79,13 @@ public static partial class SrdParsers
         _ => throw new FormatException($"Unsupported weapon priority: '{value}'.")
     };
 
-    public static Range ParseRange(string value) => value.Trim() switch
+    public static RangeType ParseRange(string value) => value.Trim() switch
     {
-        "Melee" => Range.Melee,
-        "Very Close" => Range.VeryClose,
-        "Close" => Range.Close,
-        "Far" => Range.Far,
-        "Very Far" => Range.VeryFar,
+        "Melee" => RangeType.Melee,
+        "Very Close" => RangeType.VeryClose,
+        "Close" => RangeType.Close,
+        "Far" => RangeType.Far,
+        "Very Far" => RangeType.VeryFar,
         _ => throw new FormatException($"Unsupported range: '{value}'.")
     };
 
@@ -100,7 +98,7 @@ public static partial class SrdParsers
 
     public static TraitType ParseTrait(string value) => ParseEnum<TraitType>(value, "trait");
 
-    public static DomainEnum ParseDomain(string value) => ParseEnum<DomainEnum>(value, "domain");
+    public static DomainType ParseDomain(string value) => ParseEnum<DomainType>(value, "domain");
 
     public static AbilityType ParseAbilityType(string value) => ParseEnum<AbilityType>(value, "type");
 


### PR DESCRIPTION
Renamed Range to RangeType because of conflicting name with Range class.
Renamed DomainEnum to DomainType because if matched my existing namingconvention better