### PR TITLE
Tests and refactors

### DIFF
--- a/Core/Entities/Armor.cs
+++ b/Core/Entities/Armor.cs
@@ -6,9 +6,9 @@ namespace Core.Entities;
 public class Armor
 {
     public int Id { get; set; }
-    public Tier Tier { get; set; }
+    public int Tier { get; set; }
     public string Name { get; set; } = string.Empty;
     public DamageThresholds DamageThresholds { get; set; } = new(0,0);
     public int ArmorScore { get; set; }
-    public List<Feature> Features { get; set; } = new();
+    public Feature? Feature { get; set; }
 }

--- a/Core/Entities/Weapon.cs
+++ b/Core/Entities/Weapon.cs
@@ -13,6 +13,6 @@ public class Weapon
     public Burden Burden { get; set; }
     public RangeType RangeType { get; set; }
     public WeaponPriority Category { get; set; }
-    public List<Feature> Features { get; set; } = new();
-    public Tier Tier { get; set; }
+    public Feature? Feature { get; set; }
+    public int Tier { get; set; }
 }

--- a/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/Loading/SrdJsonLoaderTests.cs
+++ b/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/Loading/SrdJsonLoaderTests.cs
@@ -1,3 +1,5 @@
+using Core.Enums;
+using DaggerheartHelper.Tests.Srd.Ingestion.Tests.Models;
 using Srd.Ingestion.Loading;
 using Xunit;
 
@@ -22,23 +24,40 @@ public class SrdJsonLoaderTests
         var gambeson = Assert.Single(catalog.Armors, x => x.Name == "Gambeson Armor");
         Assert.Equal(1, gambeson.Tier);
         Assert.Equal(3, gambeson.ArmorScore);
-        Assert.Equal(new Core.ValueObjects.DamageThresholds(5, 11), gambeson.DamageThresholds);
-        Assert.Single(gambeson.Features);
-        Assert.Equal("Flexible", gambeson.Features[0].Name);
+        Assert.Equal(new(5, 11), gambeson.DamageThresholds);
+        Assert.Equal("Flexible", gambeson.Feature?.Name);
 
         var broadsword = Assert.Single(catalog.Weapons, x => x.Name == "Broadsword");
         Assert.Equal(1, broadsword.Tier);
-        Assert.Equal(Core.Enums.Burden.OneHanded, broadsword.Burden);
-        Assert.Equal(Core.Enums.WeaponPriority.Primary, broadsword.Priority);
-        Assert.Equal(Core.Enums.TraitType.Agility, broadsword.Trait);
-        Assert.Equal(Core.Enums.RangeType.Melee, broadsword.RangeType);
-        Assert.Equal(new Core.ValueObjects.Damage(new Core.ValueObjects.Dice(1, 8), 0, Core.Enums.DamageType.Physical), broadsword.Damage);
+        Assert.Equal(Burden.OneHanded, broadsword.Burden);
+        Assert.Equal(WeaponPriority.Primary, broadsword.Priority);
+        Assert.Equal(TraitType.Agility, broadsword.Trait);
+        Assert.Equal(RangeType.Melee, broadsword.RangeType);
+        Assert.Equal(new(new(1, 8), 0, DamageType.Physical), broadsword.Damage);
 
         var runeWard = Assert.Single(catalog.Abilities, x => x.Name == "Rune Ward");
-        Assert.Equal(Core.Enums.DomainType.Arcana, runeWard.Domain);
+        Assert.Equal(DomainType.Arcana, runeWard.Domain);
         Assert.Equal(1, runeWard.Level);
         Assert.Equal(0, runeWard.RecallCost);
-        Assert.Equal(Core.Enums.AbilityType.Spell, runeWard.Type);
+        Assert.Equal(AbilityType.Spell, runeWard.Type);
+        
+        var troubadour = Assert.Single(catalog.Subclasses, x => x.Name == "Troubadour");
+        Assert.Equal(TraitType.Presence, troubadour.SpellcastTrait);
+        Assert.Equal("Gifted Performer", troubadour.Foundation.Name);
+        
+        var bard = Assert.Single(catalog.Classes, x => x.Name == "Bard");
+        Assert.Equal("Rally", bard.ClassFeature.Name);
+        Assert.Equal(10, bard.BaseEvasion);
+        Assert.Equal(DomainType.Grace, bard.Domain1);
+        Assert.Equal(bard.Subclasses.Single(s => s.Name == "Troubadour"), troubadour);
+        
+        var clank =  Assert.Single(catalog.Ancestries, x => x.Name == "Clank");
+        Assert.Contains("sentient mechanical beings", clank.Description);
+        Assert.Equal("Efficient", clank.Features.First(x => x.Name == "Efficient").Name);
+        
+        var highborne = Assert.Single(catalog.Communities, x => x.Name == "Highborne");
+        Assert.Contains("life of elegance, opulence, and prestige",  highborne.Description);
+        Assert.Equal("Privilege",  highborne.Features.First(x => x.Name == "Privilege").Name);
     }
 
     [Fact]
@@ -56,6 +75,14 @@ public class SrdJsonLoaderTests
         Assert.NotEmpty(catalog.Weapons);
         Assert.NotEmpty(catalog.Abilities);
     }
+    
+    [Fact]
+    public async Task LoadFileAsync_TrimsLoadedEntries()
+    {
+        var actual = await SrdJsonLoader.LoadFileAsync<TestInfo>(TestRepoPaths.LocalSrdJsonDirectory, "untrimmed.json", CancellationToken.None);
+
+        Assert.Equal("Test McTestson", actual[0].Name);
+        Assert.Equal("Streetway 1", actual[0].Address?.Street);
+        Assert.Equal("1234",  actual[0].Address?.Code);
+    }
 }
-
-

--- a/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/Mapping/SrdEntityMapperTests.cs
+++ b/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/Mapping/SrdEntityMapperTests.cs
@@ -1,4 +1,5 @@
 using Core.Enums;
+using Core.ValueObjects;
 using Srd.Ingestion.Domain;
 using Srd.Ingestion.Mapping;
 using Xunit;
@@ -14,17 +15,16 @@ public class SrdEntityMapperTests
             "Gambeson Armor",
             1,
             3,
-            new Core.ValueObjects.DamageThresholds(5, 11),
-            [new FeatureBlock("Flexible", "+1 to Evasion")]);
+            new DamageThresholds(5, 11),
+            new FeatureBlock("Flexible", "+1 to Evasion"));
 
         var entity = card.ToEntity();
 
         Assert.Equal("Gambeson Armor", entity.Name);
-        Assert.Equal(Tier.Tier1, entity.Tier);
+        Assert.Equal(1, entity.Tier);
         Assert.Equal(3, entity.ArmorScore);
-        Assert.Equal(new Core.ValueObjects.DamageThresholds(5, 11), entity.DamageThresholds);
-        Assert.Single(entity.Features);
-        Assert.Equal("Flexible", entity.Features[0].Name);
+        Assert.Equal(new DamageThresholds(5, 11), entity.DamageThresholds);
+        Assert.Equal("Flexible", entity.Feature?.Name);
     }
 
     [Fact]
@@ -40,6 +40,97 @@ public class SrdEntityMapperTests
         Assert.Equal(0, entity.RecallCost);
         Assert.Equal(AbilityType.Spell, entity.Type);
         Assert.Equal("Text", entity.FeatureDescription);
+    }
+
+    [Fact]
+    public void ToEntity_MapsClassCardToClassEntity()
+    {
+        var feature = new FeatureBlock("FeatureName", "FeatureText");
+        var stringlist = new List<string> { "string1", "string2", "string3" };
+        var card = new ClassCard("Bard", "ClassDescription",
+            DomainType.Grace, DomainType.Codex, 10, 5,
+            new TraitScores(0, 0, -1, 1, 1, 2),
+            new List<SubclassCard>(), feature, feature,
+            stringlist, stringlist, stringlist, 
+            new ArmorCard("ArmorName",1,1, 
+                new DamageThresholds(1,2),null),
+            new List<WeaponCard>());
+        
+        var entity = card.ToEntity();
+        
+        Assert.Equal("Bard", entity.Name);
+        Assert.Equal("ClassDescription", entity.Description);
+        Assert.Equal(DomainType.Grace, entity.Domain1);
+        Assert.Equal(10, entity.BaseHealth);
+        Assert.Equal("ArmorName", entity.SuggestedArmor.Name);
+        Assert.Null(entity.SuggestedArmor.Feature);
+    }
+
+    [Fact]
+    public void ToEntity_MapsSubclassCardToSubclassEntity()
+    {
+        var feature = new FeatureBlock("FeatureName", "FeatureText");
+        var wordsmith = new SubclassCard(
+            "Wordsmith", 
+            "SubclassDescription",
+            TraitType.Presence,
+            feature, feature, feature);
+        
+        var entity  = wordsmith.ToEntity();
+        Assert.Equal("Wordsmith", entity.Name);
+        Assert.Equal("SubclassDescription", entity.Description);
+        Assert.Equal(TraitType.Presence, entity.SpellCastingTraitType);
+        Assert.Equal("FeatureName", entity.Foundation.Name);
+    }
+
+    [Fact]
+    public void ToEntity_MapsAncestryAndCommunitCardsToHeritageEntity()
+    {
+        var ancestry = new AncestryCard(
+            "AncestryName",
+            "AncestryDescription",
+            new List<FeatureBlock>(),
+            HeritageType.Ancestry);
+
+        var community = new CommunityCard(
+            "CommunityName",
+            "CommunityDescription",
+            new List<FeatureBlock>(),
+            "Note",
+            HeritageType.Community);
+
+        var ancestryEntity = ancestry.ToEntity();
+        var communityEntity = community.ToEntity();
+
+        Assert.NotNull(ancestryEntity);
+        Assert.NotNull(communityEntity);
+        Assert.Equal("AncestryName", ancestryEntity.Name);
+        Assert.Equal("AncestryDescription", ancestryEntity.Description);
+        Assert.Equal(HeritageType.Ancestry, ancestryEntity.HeritageType);
+        Assert.Equal(HeritageType.Community, communityEntity.HeritageType);
+        Assert.Empty(ancestryEntity.Features);
+        Assert.Equal(community.Note, communityEntity.Note);
+        Assert.Equal(ancestryEntity.GetType(), communityEntity.GetType());
+    }
+
+    [Fact]
+    public void ToEntity_MapsWeaponCardToWeaponEntity()
+    {
+        var weapon = new WeaponCard(
+            "Broadsword",
+            1,
+            Burden.OneHanded,
+            WeaponPriority.Primary,
+            TraitType.Agility,
+            RangeType.Melee,
+            new Damage(new Dice(1, 8), 0, DamageType.Physical), 
+            null
+        );
+        
+        var entity = weapon.ToEntity();
+        
+        Assert.Equal("Broadsword", entity.Name);
+        Assert.Equal(1, entity.Tier);
     }
 }
 

--- a/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/Models/TestInfo.cs
+++ b/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/Models/TestInfo.cs
@@ -1,0 +1,22 @@
+using System.Text.Json.Serialization;
+
+namespace DaggerheartHelper.Tests.Srd.Ingestion.Tests.Models;
+
+public class TestInfo
+{
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("address")]
+    public Address? Address { get; set; }
+}
+
+public class Address
+{
+    [JsonPropertyName("street")]
+    public string? Street { get; set; }
+
+    [JsonPropertyName("code")]
+    public string? Code { get; set; }
+}
+

--- a/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/Parsing/SrdParsersTests.cs
+++ b/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/Parsing/SrdParsersTests.cs
@@ -1,5 +1,6 @@
 using Core.Enums;
 using Core.ValueObjects;
+using Srd.Ingestion.Domain;
 using Srd.Ingestion.Parsing;
 using Srd.Ingestion.Raw;
 using Xunit;
@@ -61,8 +62,19 @@ public class SrdParsersTests
                 new RawFeatureDto { Name = "Flexible", Text = "+1 to Evasion" }
             ]);
 
-        Assert.Single(features);
-        Assert.Equal(new global::Srd.Ingestion.Domain.FeatureBlock("Flexible", "+1 to Evasion"), features[0]);
+        Assert.Single(features!);
+        Assert.Equal(new FeatureBlock("Flexible", "+1 to Evasion"), features?[0]);
+    }
+    
+    [Fact]
+    public void ParseFeature_ReturnsCorrectValues()
+    {
+        var feature = SrdParsers.ParseFeature(new RawFeatureDto()
+        { Name = "Flexible", Text = "+1 to Evasion" });
+        
+        Assert.Null(SrdParsers.ParseFeature(null));
+        Assert.NotNull(feature);
+        Assert.Equal(new FeatureBlock("Flexible", "+1 to Evasion"), feature);
     }
 
     [Fact]

--- a/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/TestData/Json/untrimmed.json
+++ b/Daggerheart-Helper.Tests/Srd.Ingestion.Tests/TestData/Json/untrimmed.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": " Test McTestson ",
+    "address": {
+      "street": "  Streetway 1",
+      "code": "1234  "
+    }
+  }
+]

--- a/Infrastructure/Persistence/DaggerheartDbContext.cs
+++ b/Infrastructure/Persistence/DaggerheartDbContext.cs
@@ -45,31 +45,13 @@ public class DaggerheartDbContext : DbContext
             entity.HasKey(x => x.Id);
             entity.Property(x => x.Name).IsRequired().HasMaxLength(200);
             entity.Property(x => x.ArmorScore).IsRequired();
+            entity.Property(x => x.Feature);
             entity.OwnsOne(x => x.DamageThresholds, owned =>
             {
                 owned.Property(x => x.Minor).HasColumnName("MinorThreshold");
                 owned.Property(x => x.Major).HasColumnName("MajorThreshold");
                 owned.Property(x => x.Severe).HasColumnName("SevereThreshold");
             });
-            entity.HasMany(x => x.Features)
-                .WithMany(x => x.Armors)
-                .UsingEntity<Dictionary<string, object>>(
-                    "ArmorFeatures",
-                    right => right
-                        .HasOne<Feature>()
-                        .WithMany()
-                        .HasForeignKey("FeatureId")
-                        .OnDelete(DeleteBehavior.Cascade),
-                    left => left
-                        .HasOne<Armor>()
-                        .WithMany()
-                        .HasForeignKey("ArmorId")
-                        .OnDelete(DeleteBehavior.Cascade),
-                    join =>
-                    {
-                        join.HasKey("ArmorId", "FeatureId");
-                        join.ToTable("ArmorFeatures");
-                    });
         });
 
         modelBuilder.Entity<Character>(entity =>
@@ -204,6 +186,7 @@ public class DaggerheartDbContext : DbContext
             entity.Property(x => x.BaseHealth).IsRequired();
             entity.Property(x => x.Domain1).IsRequired();
             entity.Property(x => x.Domain2).IsRequired();
+            entity.Property(x => x.HopeFeature);
 
             entity.OwnsOne(x => x.SuggestedTraits, owned =>
             {
@@ -225,10 +208,6 @@ public class DaggerheartDbContext : DbContext
                 .HasForeignKey("ClassFeatureId")
                 .OnDelete(DeleteBehavior.Restrict);
 
-            entity.HasOne(x => x.HopeFeature)
-                .WithMany()
-                .HasForeignKey("HopeFeatureId")
-                .OnDelete(DeleteBehavior.Restrict);
 
             entity.HasMany(x => x.SuggestedWeapons)
                 .WithMany()
@@ -303,6 +282,7 @@ public class DaggerheartDbContext : DbContext
             entity.HasKey(x => x.Id);
             entity.Property(x => x.Name).IsRequired().HasMaxLength(200);
             entity.Property(x => x.Description).IsRequired();
+            entity.Property(x => x.Feature);
             entity.OwnsOne(x => x.Damage, damage =>
             {
                 damage.Property(x => x.Bonus).HasColumnName("DamageBonus");
@@ -313,25 +293,6 @@ public class DaggerheartDbContext : DbContext
                     dice.Property(x => x.NumberOfSides).HasColumnName("DamageDiceSides");
                 });
             });
-            entity.HasMany(x => x.Features)
-                .WithMany(x => x.Weapons)
-                .UsingEntity<Dictionary<string, object>>(
-                    "WeaponFeatures",
-                    right => right
-                        .HasOne<Feature>()
-                        .WithMany()
-                        .HasForeignKey("FeatureId")
-                        .OnDelete(DeleteBehavior.Cascade),
-                    left => left
-                        .HasOne<Weapon>()
-                        .WithMany()
-                        .HasForeignKey("WeaponId")
-                        .OnDelete(DeleteBehavior.Cascade),
-                    join =>
-                    {
-                        join.HasKey("WeaponId", "FeatureId");
-                        join.ToTable("WeaponFeatures");
-                    });
         });
     }
 

--- a/Srd.Ingestion/Domain/ArmorCard.cs
+++ b/Srd.Ingestion/Domain/ArmorCard.cs
@@ -7,6 +7,6 @@ public sealed record ArmorCard(
     int Tier,
     int ArmorScore,
     DamageThresholds DamageThresholds,
-    IReadOnlyList<FeatureBlock> Features);
+    FeatureBlock? Feature);
 
 

--- a/Srd.Ingestion/Domain/WeaponCard.cs
+++ b/Srd.Ingestion/Domain/WeaponCard.cs
@@ -10,8 +10,7 @@ public sealed record WeaponCard(
     WeaponPriority Priority,
     TraitType Trait,
     RangeType RangeType,
-    DamageType DamageKind,
     Damage Damage,
-    IReadOnlyList<FeatureBlock> Features);
+    FeatureBlock? Feature);
 
 

--- a/Srd.Ingestion/Loading/SrdJsonLoader.cs
+++ b/Srd.Ingestion/Loading/SrdJsonLoader.cs
@@ -65,7 +65,7 @@ public sealed class SrdJsonLoader : ISrdJsonLoader
             SrdParsers.ParseTier(raw.Tier),
             SrdParsers.ParseInt(raw.BaseScore, "base_score"),
             SrdParsers.ParseThresholds(raw.BaseThresholds),
-            SrdParsers.ParseFeatures(raw.Features));
+            SrdParsers.ParseFeature(raw.Feature?[0]));
     }
 
     private static WeaponCard ToWeaponCard(RawWeaponDto raw)
@@ -77,9 +77,8 @@ public sealed class SrdJsonLoader : ISrdJsonLoader
             SrdParsers.ParseWeaponPriority(raw.PrimaryOrSecondary),
             SrdParsers.ParseTrait(raw.Trait),
             SrdParsers.ParseRange(raw.Range),
-            SrdParsers.ParseDamageKind(raw.PhysicalOrMagical),
-            SrdParsers.ParseDamage(raw.Damage, SrdParsers.ParseDamageKind(raw.PhysicalOrMagical)),
-            SrdParsers.ParseFeatures(raw.Features));
+            SrdParsers.ParseDamage(raw.Damage),
+            SrdParsers.ParseFeature(raw.Feature?[0]));
     }
 
     private static AbilityCard ToAbilityCard(RawAbilityDto raw)
@@ -98,7 +97,7 @@ public sealed class SrdJsonLoader : ISrdJsonLoader
         return new AncestryCard(
             raw.Name,
             raw.Description,
-            SrdParsers.ParseFeatures(raw.Features),
+            SrdParsers.ParseFeatures(raw.Features)!,
             HeritageType.Ancestry);
     }
     
@@ -107,7 +106,7 @@ public sealed class SrdJsonLoader : ISrdJsonLoader
         return new CommunityCard(
             raw.Name,
             raw.Description,
-            SrdParsers.ParseFeatures(raw.Feature),
+            SrdParsers.ParseFeatures(raw.Feature)!,
             raw.Note,
             HeritageType.Community);
     }
@@ -124,8 +123,8 @@ public sealed class SrdJsonLoader : ISrdJsonLoader
             SrdParsers.ParseTraitScores(raw.SuggestedTraits),
             subclasses.Where(s => string.Equals(s.Name, raw.SubClass1, StringComparison.OrdinalIgnoreCase) || 
                                  string.Equals(s.Name, raw.SubClass2, StringComparison.OrdinalIgnoreCase)).ToList(),
-            SrdParsers.ParseFeature(raw.ClassFeature[0]),
-            SrdParsers.ParseFeature(new RawFeatureDto() { Name = raw.HopeFeatureName, Text = raw.HopeFeatureText }),
+            SrdParsers.ParseFeature(raw.ClassFeature[0])!,
+            SrdParsers.ParseFeature(new RawFeatureDto { Name = raw.HopeFeatureName, Text = raw.HopeFeatureText })!,
             SrdParsers.ParseItems(raw.Items).ToList(),
             SrdParsers.ParseQuestions(raw.BackgroundQuestions),
             SrdParsers.ParseQuestions(raw.ConnectionQuestions),
@@ -141,8 +140,8 @@ public sealed class SrdJsonLoader : ISrdJsonLoader
             raw.Name,
             raw.Description,
             string.IsNullOrEmpty(raw.SpellcastTrait) ? null : SrdParsers.ParseTrait(raw.SpellcastTrait),
-            SrdParsers.ParseFeature(raw.Foundation[0]), 
-            SrdParsers.ParseFeature(raw.Specialization[0]), 
-            SrdParsers.ParseFeature(raw.Mastery[0]));
+            SrdParsers.ParseFeature(raw.Foundation[0])!, 
+            SrdParsers.ParseFeature(raw.Specialization[0])!, 
+            SrdParsers.ParseFeature(raw.Mastery[0])!);
     }
 }

--- a/Srd.Ingestion/Mapping/SrdEntityMapper.cs
+++ b/Srd.Ingestion/Mapping/SrdEntityMapper.cs
@@ -1,5 +1,4 @@
 using Core.Entities;
-using Core.Enums;
 using Srd.Ingestion.Domain;
 
 namespace Srd.Ingestion.Mapping;
@@ -19,10 +18,10 @@ public static class SrdEntityMapper
         return new Armor
         {
             Name = card.Name,
-            Tier = ParseTier(card.Tier),
+            Tier = card.Tier,
             ArmorScore = card.ArmorScore,
             DamageThresholds = card.DamageThresholds,
-            Features = card.Features.Select(ToEntity).ToList()
+            Feature = ToEntity(card.Feature)
         };
     }
 
@@ -31,14 +30,14 @@ public static class SrdEntityMapper
         return new Weapon
         {
             Name = card.Name,
-            Tier = ParseTier(card.Tier),
+            Tier = card.Tier,
             Trait = card.Trait,
             Burden = card.Burden,
             RangeType = card.RangeType,
             Category = card.Priority,
             Damage = card.Damage,
             Description = string.Empty,
-            Features = card.Features.Select(ToEntity).ToList()
+            Feature = ToEntity(card.Feature)
         };
     }
 
@@ -61,7 +60,7 @@ public static class SrdEntityMapper
         {
             Name = card.Name,
             Description = card.Description,
-            Features = card.Features.Select(ToEntity).ToList(),
+            Features = card.Features.Select(ToEntity).ToList()!,
             Note = card.Note,
             HeritageType = card.HeritageType
         };
@@ -73,9 +72,9 @@ public static class SrdEntityMapper
         {
             Name = card.Name,
             Description = card.Description,
-            Foundation = ToEntity(card.Foundation),
-            Specialization = ToEntity(card.Specialization),
-            Mastery =  ToEntity(card.Mastery),
+            Foundation = ToEntity(card.Foundation)!,
+            Specialization = ToEntity(card.Specialization)!,
+            Mastery =  ToEntity(card.Mastery)!,
             SpellCastingTraitType = card.SpellcastTrait
         };
     }
@@ -94,30 +93,22 @@ public static class SrdEntityMapper
             SuggestedArmor = card.SuggestedArmor.ToEntity(),
             SuggestedWeapons = card.SuggestedWeapons.ToEntities(),
             Subclasses = card.Subclasses.Select(ToEntity).ToList(),
-            ClassFeature = ToEntity(card.ClassFeature),
-            HopeFeature = ToEntity(card.HopeFeature),
+            ClassFeature = ToEntity(card.ClassFeature)!,
+            HopeFeature = ToEntity(card.HopeFeature)!,
             BackgroundQuestions = card.BackgroundQuestions,
             ConnectionQuestions = card.ConnectionQuestions,
             Items = card.Items,
         };
     }
     
-    private static Feature ToEntity(FeatureBlock feature)
+    private static Feature? ToEntity(FeatureBlock? feature)
     {
-        return new Feature
+        return feature is null ? null :
+            new Feature
         {
             Name = feature.Name,
             Description = feature.Text
         };
     }
-
-    private static Tier ParseTier(int tier) => tier switch
-    {
-        1 => Tier.Tier1,
-        2 => Tier.Tier2,
-        3 => Tier.Tier3,
-        4 => Tier.Tier4,
-        _ => throw new ArgumentOutOfRangeException(nameof(tier), tier, "Tier must be between 1 and 4.")
-    };
 }
 

--- a/Srd.Ingestion/Parsing/SrdParsers.cs
+++ b/Srd.Ingestion/Parsing/SrdParsers.cs
@@ -45,22 +45,17 @@ public static partial class SrdParsers
         return new Damage(parsed.Dice, parsed.Bonus, kind);
     }
 
-    public static Damage ParseDamage(string value, DamageType damageType)
+    public static FeatureBlock? ParseFeature(RawFeatureDto? feature)
     {
-        var parsed = ParseDamageParts(value);
-        return new Damage(parsed.Dice, parsed.Bonus, damageType);
+        return feature is null ? null :
+        new FeatureBlock(feature.Name, feature.Text);
     }
 
-    public static FeatureBlock ParseFeature(RawFeatureDto feature)
-    {
-        return new FeatureBlock(feature.Name, feature.Text);
-    }
-
-    public static IReadOnlyList<FeatureBlock> ParseFeatures(List<RawFeatureDto>? features)
+    public static IReadOnlyList<FeatureBlock?>? ParseFeatures(List<RawFeatureDto>? features)
     {
         if (features is null || features.Count == 0)
         {
-            return [];
+            return null;
         }
 
         return features

--- a/Srd.Ingestion/Raw/RawArmorDto.cs
+++ b/Srd.Ingestion/Raw/RawArmorDto.cs
@@ -17,6 +17,6 @@ public sealed class RawArmorDto
     public string BaseThresholds { get; set; } = string.Empty;
 
     [JsonPropertyName("feature")]
-    public List<RawFeatureDto>? Features { get; set; }
+    public List<RawFeatureDto>? Feature { get; set; }
 }
 

--- a/Srd.Ingestion/Raw/RawWeaponDto.cs
+++ b/Srd.Ingestion/Raw/RawWeaponDto.cs
@@ -29,6 +29,6 @@ public sealed class RawWeaponDto
     public string PhysicalOrMagical { get; set; } = string.Empty;
 
     [JsonPropertyName("feature")]
-    public List<RawFeatureDto>? Features { get; set; }
+    public List<RawFeatureDto>? Feature { get; set; }
 }
 


### PR DESCRIPTION
This pull request refactors how features are represented for `Armor` and `Weapon` entities, moving from lists of features to a single optional feature. It updates the domain models, entity classes, database mappings, and related tests to align with this new structure. Additionally, the PR extends test coverage for entity mapping and parsing, and introduces a test for trimming loaded JSON entries.

**Refactoring feature representation:**

* Changed the `Armor` and `Weapon` entities and their corresponding domain models (`ArmorCard`, `WeaponCard`) to use a single optional `Feature` instead of a list of features. Updated all related code, including mapping and parsing logic, to accommodate this change. [[1]](diffhunk://#diff-fe13146440092665ba624c052efb51b797b352736dc5702b3b039a3f46dd9655L9-R13) [[2]](diffhunk://#diff-27dbcbbf6b4214abf8503bcf252cffeca6385782a285934e5cdc6b0a8fc59455L16-R17) [[3]](diffhunk://#diff-cb9e5ac722d93e734cd46e7c8985f33a87e0a3f75b94169004ee82748de40db3L10-R10) [[4]](diffhunk://#diff-402589e31e1d75cd92f324177c9b03f66f3dd6b55b607559d718fe90e2741d2cL13-R14) [[5]](diffhunk://#diff-8f81e2e870b137670c2a4429f4366b7d95166495d9d95e96fb7b598a33269bbfL68-R68) [[6]](diffhunk://#diff-8f81e2e870b137670c2a4429f4366b7d95166495d9d95e96fb7b598a33269bbfL80-R81)
* Updated Entity Framework Core mappings in `DaggerheartDbContext` to remove many-to-many relationships for features and instead map a single feature property for `Armor` and `Weapon`. [[1]](diffhunk://#diff-64f7244ae4ca70b3f17fa27da6265e4678608a7efae02f7eeac6db7725a284b2R48-L72) [[2]](diffhunk://#diff-64f7244ae4ca70b3f17fa27da6265e4678608a7efae02f7eeac6db7725a284b2R189) [[3]](diffhunk://#diff-64f7244ae4ca70b3f17fa27da6265e4678608a7efae02f7eeac6db7725a284b2L228-L231) [[4]](diffhunk://#diff-64f7244ae4ca70b3f17fa27da6265e4678608a7efae02f7eeac6db7725a284b2R285) [[5]](diffhunk://#diff-64f7244ae4ca70b3f17fa27da6265e4678608a7efae02f7eeac6db7725a284b2L316-L334)

**Test and parsing improvements:**

* Updated and expanded unit tests to reflect the new single-feature structure for armors and weapons, and added mapping tests for class, subclass, ancestry, community, and weapon entities. [[1]](diffhunk://#diff-892866e45f56ef5ee3aff69588a2acd0785e81cf6b9c693b0799e2b425f1d8d6L17-R27) [[2]](diffhunk://#diff-892866e45f56ef5ee3aff69588a2acd0785e81cf6b9c693b0799e2b425f1d8d6R44-R134)
* Improved feature parsing logic and added a test to ensure correct parsing of single features.
* Updated test assertions in `SrdJsonLoaderTests` to match the new feature structure and added tests for additional entities.

**Test data and utility additions:**

* Added new test models (`TestInfo`, `Address`) and a test JSON file (`untrimmed.json`) to support testing of JSON loading and trimming. [[1]](diffhunk://#diff-a6bd240fd77a17a3390d3b1097ef6e8a5156ea0834f0c7c5ea2621b422d88ff2R1-R22) [[2]](diffhunk://#diff-5a16dba371a4c0105ee4b9b41832e5f8b342595d5fc303a7564665ac5dcbdaaaR1-R9)
* Added a test to verify that loaded JSON entries are trimmed of whitespace.

**Code cleanup and minor improvements:**

* Cleaned up unused code and imports, and improved nullability handling in parsing and mapping logic. [[1]](diffhunk://#diff-e18000bd419abc6cb89772c573df05f6eea1900da626ab112f096917aa358001R1-R2) [[2]](diffhunk://#diff-892866e45f56ef5ee3aff69588a2acd0785e81cf6b9c693b0799e2b425f1d8d6R2) [[3]](diffhunk://#diff-07e3e961f863b043c0888628c9bc674932dd7f1b3987b2fdceda33d43f9fc98cR3) [[4]](diffhunk://#diff-8f81e2e870b137670c2a4429f4366b7d95166495d9d95e96fb7b598a33269bbfL101-R100) [[5]](diffhunk://#diff-8f81e2e870b137670c2a4429f4366b7d95166495d9d95e96fb7b598a33269bbfL110-R109)