### PR TITLE
Fix: recreate DB on schema mismatch for existing Azure deployments

### DIFF
--- a/Infrastructure/Persistence/Seed.cs
+++ b/Infrastructure/Persistence/Seed.cs
@@ -16,7 +16,19 @@ public class Seed
     var logger = scope.ServiceProvider.GetRequiredService<ILogger<Seed>>();
     
     // Create database schema from model
-    await context.Database.EnsureCreatedAsync();
+    var created = await context.Database.EnsureCreatedAsync();
+    if (!created)
+    {
+        // Database existed from prior deployment — check if schema is current
+        var hasAdv = (await context.Database
+            .ExecuteSqlRawAsync("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='Adversaries'")) > 0;
+        if (!hasAdv)
+        {
+            logger.LogWarning("Database schema outdated (missing Adversaries). Recreating...");
+            await context.Database.EnsureDeletedAsync();
+            await context.Database.EnsureCreatedAsync();
+        }
+    }
     await EnsureConcurrencyTriggersAsync(context);
     
     // Check if already seeded


### PR DESCRIPTION
Azure-databasen saknade Adversaries-tabellen eftersom EnsureCreatedAsync inte uppdaterar befintliga databaser och Seed hoppade över pga early-return. Ny logik: om tabell saknas → återskapa DB + kör full seed.

Closes #120 (supplement)