### PR TITLE
feat: reference catalog, domain colors, and styling refactoring

### DIFF
--- a/Daggerheart-Helper.Shared/Components/CardHeader.razor
+++ b/Daggerheart-Helper.Shared/Components/CardHeader.razor
@@ -1,0 +1,15 @@
+@namespace DaggerheartHelper.Shared.Components
+
+<div class="card-header">
+    <div class="char-title">
+        <h3>@Title</h3>
+        <span class="char-class">@Subtitle</span>
+    </div>
+    @ChildContent
+</div>
+
+@code {
+    [Parameter] public string Title { get; set; } = string.Empty;
+    [Parameter] public string Subtitle { get; set; } = string.Empty;
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+}

--- a/Daggerheart-Helper.Shared/Components/CardHeader.razor.css
+++ b/Daggerheart-Helper.Shared/Components/CardHeader.razor.css
@@ -1,0 +1,20 @@
+.card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    padding-bottom: 12px;
+    margin-bottom: 12px;
+}
+
+.char-title h3 {
+    margin: 0 0 4px 0;
+    font-size: 1.35rem;
+    color: var(--dh-neutral);
+}
+
+.char-class {
+    font-size: 0.82rem;
+    color: var(--dh-purple);
+    font-weight: 500;
+}

--- a/Daggerheart-Helper.Shared/Components/PageHeader.razor
+++ b/Daggerheart-Helper.Shared/Components/PageHeader.razor
@@ -1,0 +1,25 @@
+@namespace DaggerheartHelper.Shared.Components
+
+<div class="dashboard-header">
+    <FluentStack VerticalAlignment="VerticalAlignment.Center" Gap="12">
+        @BackButton
+        <FluentStack Orientation="Orientation.Vertical">
+            <h2 class="page-title">@Title</h2>
+            @if (!string.IsNullOrEmpty(Subtitle))
+            {
+                <p class="page-subtitle">@Subtitle</p>
+            }
+        </FluentStack>
+        <FluentStack HorizontalAlignment="HorizontalAlignment.End">
+            @ChildContent
+        </FluentStack>
+    </FluentStack>
+</div>
+<FluentDivider Style="margin-bottom: 12px; margin-top: 12px;" />
+
+@code {
+    [Parameter] public string Title { get; set; } = string.Empty;
+    [Parameter] public string? Subtitle { get; set; }
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+    [Parameter] public RenderFragment? BackButton { get; set; }
+}

--- a/Daggerheart-Helper.Shared/Layout/MainLayout.razor
+++ b/Daggerheart-Helper.Shared/Layout/MainLayout.razor
@@ -1,24 +1,24 @@
 ﻿@inherits LayoutComponentBase
 
-<div class="background-container">
-    <FluentMainLayout NavMenuTitle="Navigation menu">
-        <Header><h3>Daggerheart Helper</h3></Header>
-        <NavMenuContent>
-            <FluentNavLink Href="/" IconStart="@(new Icons.Filled.Size20.Home())">Home</FluentNavLink>
-            <FluentNavLink Href="/CharacterCreator" IconStart="@(new Icons.Filled.Size20.PersonAdd())">Character Creator</FluentNavLink>
-            <FluentNavLink Href="/Characters" IconStart="@(new Icons.Filled.Size20.PeopleCommunity())">My Characters</FluentNavLink>
-            <FluentNavLink Href="/dm-tools" IconStart="@(new Icons.Filled.Size20.PersonLightning())">DM Tools</FluentNavLink>
-        </NavMenuContent>
-        <Body>
+<FluentMainLayout NavMenuTitle="Navigation menu">
+    <Header><h3>Daggerheart Helper</h3></Header>
+    <NavMenuContent>
+        <FluentNavLink Href="/" IconStart="@(new Icons.Filled.Size20.Home())">Home</FluentNavLink>
+        <FluentNavLink Href="/CharacterCreator" IconStart="@(new Icons.Filled.Size20.PersonAdd())">Character Creator</FluentNavLink>
+        <FluentNavLink Href="/Characters" IconStart="@(new Icons.Filled.Size20.PeopleCommunity())">My Characters</FluentNavLink>
+        <FluentNavLink Href="/dm-tools" IconStart="@(new Icons.Filled.Size20.PersonLightning())">DM Tools</FluentNavLink>
+    </NavMenuContent>
+    <Body>
+        <div class="dashboard-container">
             @Body
-            <FluentToastProvider />
-            <FluentDialogProvider />
-            <FluentTooltipProvider />
-            <FluentMessageBarProvider />
-            <FluentMenuProvider />
-        </Body>
-    </FluentMainLayout>
-</div>
+        </div>
+        <FluentToastProvider />
+        <FluentDialogProvider />
+        <FluentTooltipProvider />
+        <FluentMessageBarProvider />
+        <FluentMenuProvider />
+    </Body>
+</FluentMainLayout>
 
 <div id="blazor-error-ui" data-nosnippet>
     An unhandled error has occurred.

--- a/Daggerheart-Helper.Shared/Layout/MainLayout.razor
+++ b/Daggerheart-Helper.Shared/Layout/MainLayout.razor
@@ -15,6 +15,7 @@
             <FluentDialogProvider />
             <FluentTooltipProvider />
             <FluentMessageBarProvider />
+            <FluentMenuProvider />
         </Body>
     </FluentMainLayout>
 </div>

--- a/Daggerheart-Helper.Shared/Layout/MainLayout.razor.css
+++ b/Daggerheart-Helper.Shared/Layout/MainLayout.razor.css
@@ -1,7 +1,0 @@
-.background-container {
-    min-height: 100dvh;
-    background-image: url('Images/dh-background.jpg');
-    background-size: cover;
-    background-attachment: fixed;
-    background-position: center;
-}

--- a/Daggerheart-Helper.Shared/Pages/AddItemPanel.razor.css
+++ b/Daggerheart-Helper.Shared/Pages/AddItemPanel.razor.css
@@ -10,7 +10,7 @@
 .panel-section-title {
     font-size: 0.85rem;
     font-weight: 600;
-    color: var(--dh-purple);
+    color: var(--dh-fear);
     margin-bottom: 8px;
     letter-spacing: 0.3px;
 }
@@ -29,8 +29,8 @@
 }
 
 .panel-item-btn:hover {
-    background: color-mix(in srgb, var(--dh-purple) 8%, transparent);
-    border-color: color-mix(in srgb, var(--dh-purple) 20%, transparent);
+    background: color-mix(in srgb, var(--dh-fear) 8%, transparent);
+    border-color: color-mix(in srgb, var(--dh-fear) 20%, transparent);
 }
 
 .panel-common-grid {

--- a/Daggerheart-Helper.Shared/Pages/AdversaryBrowser.razor
+++ b/Daggerheart-Helper.Shared/Pages/AdversaryBrowser.razor
@@ -4,16 +4,14 @@
 
 <PageTitle>Adversary Browser — DM Tools</PageTitle>
 
-<div class="dashboard-container">
-    <div class="dashboard-header">
-        <div class="header-text">
-            <h2>Adversary Browser</h2>
-            <p>Browse and search Daggerheart adversaries from the SRD</p>
-        </div>
-        <FluentButton Appearance="Appearance.Stealth" IconStart="@(new Icons.Filled.Size20.ArrowLeft())" OnClick="@GoBack">
-            Back to DM Tools
-        </FluentButton>
-    </div>
+<PageHeader Title="Adversary Browser" Subtitle="Browse and search Daggerheart adversaries from the SRD">
+    <BackButton>
+        <FluentButton Appearance="Appearance.Stealth"
+                      IconStart="@(new Icons.Filled.Size20.ArrowLeft())"
+                      OnClick="@GoBack"
+                      Title="Back to DM Tools" />
+    </BackButton>
+</PageHeader>
 
     <div class="filters-bar">
         <FluentTextField Placeholder="Search by name..." Value="@_searchTerm" ValueChanged="@OnSearchChanged" Style="max-width: 250px;" Immediate ImmediateDelay="300" />
@@ -74,7 +72,6 @@
             </FluentDataGrid>
         </FluentStack>
     }
-</div>
 
 @if (_selected is not null)
 {

--- a/Daggerheart-Helper.Shared/Pages/AdversaryBrowser.razor.css
+++ b/Daggerheart-Helper.Shared/Pages/AdversaryBrowser.razor.css
@@ -1,33 +1,3 @@
-.dashboard-container {
-    padding: 24px;
-    background: radial-gradient(circle at top, var(--dh-bg-start) 0%, var(--dh-bg-end) 100%);
-    min-height: 90vh;
-    color: #f0f0f5;
-}
-
-.dashboard-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 16px;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-    padding-bottom: 16px;
-}
-
-.header-text h2 {
-    font-size: 1.6rem;
-    margin: 0 0 3px 0;
-    background: linear-gradient(135deg, var(--dh-purple) 0%, var(--dh-pink) 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-}
-
-.header-text p {
-    margin: 0;
-    color: var(--dh-neutral);
-    font-size: 0.85rem;
-}
-
 .filters-bar {
     display: flex;
     gap: 10px;
@@ -42,7 +12,7 @@
     align-items: center;
     justify-content: center;
     padding: 60px 0;
-    color: var(--dh-purple);
+    color: var(--dh-fear);
 }
 
 .empty-state {
@@ -81,49 +51,6 @@
 
 ::deep .adversary-grid fluent-data-grid-row {
     min-height: 32px;
-}
-
-::deep fluent-badge {
-    font-size: 0.75rem;
-    font-weight: 600;
-
-    --badge-fill-tier: color-mix(in srgb, var(--dh-purple) 15%, transparent);
-    --badge-color-tier: var(--dh-purple);
-    --badge-fill-difficulty: color-mix(in srgb, var(--dh-negative) 15%, transparent);
-    --badge-color-difficulty: var(--dh-negative);
-    --badge-fill-thresholds: color-mix(in srgb, var(--dh-purple) 15%, transparent);
-    --badge-color-thresholds: var(--dh-purple);
-    --badge-fill-hp: color-mix(in srgb, var(--dh-hp) 15%, transparent);
-    --badge-color-hp: var(--dh-hp);
-    --badge-fill-stress: color-mix(in srgb, var(--dh-stress) 15%, transparent);
-    --badge-color-stress: var(--dh-stress);
-    --badge-fill-atk: color-mix(in srgb, var(--dh-stress) 15%, transparent);
-    --badge-color-atk: var(--dh-stress);
-    --badge-fill-attack: color-mix(in srgb, var(--dh-negative) 15%, transparent);
-    --badge-color-attack: var(--dh-negative);
-    --badge-fill-exp: color-mix(in srgb, var(--dh-hope) 15%, transparent);
-    --badge-color-exp: var(--dh-hope);
-
-    --badge-fill-solo: color-mix(in srgb, var(--dh-hp) 15%, transparent);
-    --badge-color-solo: var(--dh-hp);
-    --badge-fill-bruiser: color-mix(in srgb, var(--dh-stress) 15%, transparent);
-    --badge-color-bruiser: var(--dh-stress);
-    --badge-fill-horde: color-mix(in srgb, #eab308 15%, transparent);
-    --badge-color-horde: #eab308;
-    --badge-fill-leader: color-mix(in srgb, var(--dh-purple) 15%, transparent);
-    --badge-color-leader: var(--dh-purple);
-    --badge-fill-minion: color-mix(in srgb, var(--dh-neutral) 15%, transparent);
-    --badge-color-minion: var(--dh-neutral);
-    --badge-fill-ranged: color-mix(in srgb, var(--dh-positive) 15%, transparent);
-    --badge-color-ranged: var(--dh-positive);
-    --badge-fill-skulk: color-mix(in srgb, #3b82f6 15%, transparent);
-    --badge-color-skulk: #3b82f6;
-    --badge-fill-social: color-mix(in srgb, var(--dh-pink) 15%, transparent);
-    --badge-color-social: var(--dh-pink);
-    --badge-fill-standard: color-mix(in srgb, #14b8a6 15%, transparent);
-    --badge-color-standard: #14b8a6;
-    --badge-fill-support: color-mix(in srgb, #06b6d4 15%, transparent);
-    --badge-color-support: #06b6d4;
 }
 
 .detail-overlay {
@@ -171,7 +98,7 @@
 
 .detail-subtitle {
     font-size: 0.82rem;
-    color: var(--dh-purple);
+    color: var(--dh-fear);
     font-style: italic;
     margin-bottom: 10px;
 }

--- a/Daggerheart-Helper.Shared/Pages/CharacterCreator.razor
+++ b/Daggerheart-Helper.Shared/Pages/CharacterCreator.razor
@@ -11,9 +11,10 @@
 
 <PageTitle>Create Character</PageTitle>
 
+<PageHeader Title="Character Creator" Subtitle="Create your Daggerheart character" />
+
 <a @ref="_wizardTop"></a>
-<FluentCard Style="max-width: 960px; margin: 2rem auto; padding: 2rem;">
-    @if (!string.IsNullOrEmpty(_characterName) || _selectedClass != null || _selectedAncestry != null)
+@if (!string.IsNullOrEmpty(_characterName) || _selectedClass != null || _selectedAncestry != null)
     {
         <FluentStack Class="character-summary" Orientation="Orientation.Horizontal" Wrap="true" Gap="8px">
             @if (!string.IsNullOrEmpty(_characterName))
@@ -41,7 +42,7 @@
     <FluentWizard Value="@_currentStep" ValueChanged="@OnStepChange" OnFinish="SaveCharacter" StepperPosition="StepperPosition.Top" Width="100%" Height="auto" Border="WizardBorder.None" StepperBulletSpace="140px">
         <Steps>
 
-            <FluentWizardStep Label="Class" Summary="Pick a class and subclass" OnChange="@ValidateStep">
+        <FluentWizardStep Label="Class" Summary="Pick a class and subclass" OnChange="@ValidateStep">
                 <h3>Character Name</h3>
                 <FluentTextField @bind-Value="_characterName" Placeholder="Vaelen, Arcela, Gealovan .." Required="true" Style="width: 100%; margin-bottom: 1.5rem;" />
                 <FluentDivider />
@@ -308,7 +309,7 @@
                             @foreach (var bonus in _pool)
                             {
                                 <FluentDropZone TItem="BonusChip" Draggable="true" Droppable="false" Item="@bonus">
-                                    <div style="display: inline-block; padding: 8px 20px; background: color-mix(in srgb, var(--dh-purple) 15%, transparent); border: 1px solid color-mix(in srgb, var(--dh-purple) 40%, transparent); border-radius: 8px; cursor: grab; user-select: none; font-weight: 600; font-size: 1.05rem;">
+                                    <div style="display: inline-block; padding: 8px 20px; background: color-mix(in srgb, var(--dh-fear) 15%, transparent); border: 1px solid color-mix(in srgb, var(--dh-fear) 40%, transparent); border-radius: 8px; cursor: grab; user-select: none; font-weight: 600; font-size: 1.05rem;">
                                         @bonus.Label
                                     </div>
                                 </FluentDropZone>
@@ -784,7 +785,6 @@
             <span>@_errorMessage</span>
         </FluentMessageBar>
     }
-</FluentCard>
 
 @code {
     private int _currentStep;

--- a/Daggerheart-Helper.Shared/Pages/CharacterCreator.razor.css
+++ b/Daggerheart-Helper.Shared/Pages/CharacterCreator.razor.css
@@ -39,17 +39,12 @@
 .selected-class-title {
     margin: 4px 0 8px 0;
     font-size: 1.3rem;
-    color: var(--dh-purple);
+    color: var(--dh-fear);
 }
 
 /* Accordion nested inside accordion content override */
 ::deep .selected-class-summary + fluent-accordion {
     margin-top: 12px;
-}
-
-::deep fluent-badge {
-    font-size: 0.75rem;
-    font-weight: 600;
 }
 
 /* Ancestries */
@@ -121,11 +116,5 @@
     padding: 10px 14px;
     margin-bottom: 16px;
 }
-
-::deep fluent-badge[fill="class"] { --badge-fill: color-mix(in srgb, var(--dh-purple) 20%, transparent); --badge-color: var(--dh-purple); }
-::deep fluent-badge[fill="subclass"] { --badge-fill: color-mix(in srgb, var(--dh-purple) 20%, transparent); --badge-color: #c4b5fd; }
-::deep fluent-badge[fill="ancestry"] { --badge-fill: color-mix(in srgb, var(--dh-positive) 20%, transparent); --badge-color: var(--dh-positive); }
-::deep fluent-badge[fill="community"] { --badge-fill: color-mix(in srgb, var(--dh-positive) 20%, transparent); --badge-color: #6ee7b7; }
-::deep fluent-badge[fill="name"] { --badge-fill: color-mix(in srgb, var(--dh-hope) 20%, transparent); --badge-color: var(--dh-hope); }
 
 

--- a/Daggerheart-Helper.Shared/Pages/CharacterSheet.razor
+++ b/Daggerheart-Helper.Shared/Pages/CharacterSheet.razor
@@ -74,97 +74,131 @@
         }
 
         <FluentGrid Spacing="2">
+            @* Resource Pools & Damage Thresholds*@
             <FluentGridItem Xs="12" Sm="6">
-                @* Resource Pools *@
-                <div class="card-section">
-                    <FluentGrid Spacing="2">
-                        <FluentGridItem Xs="6" Sm="3">
-                            @if (_isEditing)
-                            {
-                                <div class="pool-edit hp">
-                                    <span class="pool-label">HP</span>
-                                    <div class="pool-inputs">
-                                        <FluentNumberField @bind-Value="_editHpCurrent" Min="0" HideStep="true" Style="flex: 1 1 0; min-width: 0;" />
-                                        <span class="pool-sep">/</span>
-                                        <FluentNumberField @bind-Value="_editHpMax" Min="1" HideStep="true" Style="flex: 1 1 0; min-width: 0;" />
-                                    </div>
-                                </div>
-                            }
-                            else
-                            {
-                                <div class="chip-pool bg-hp-subtle border-hp">
-                                    <span class="text-hp text-sm">HITPOINTS</span>
-                                    <strong class="text-hp">@_character.HitPoints.Current / @_character.HitPoints.Max</strong>
-                                </div>
-                            }
-                        </FluentGridItem>
-                        <FluentGridItem Xs="6" Sm="3">
-                            @if (_isEditing)
-                            {
-                                <div class="pool-edit stress">
-                                    <span class="pool-label">STRESS</span>
-                                    <div class="pool-inputs">
-                                        <FluentNumberField @bind-Value="_editStressCurrent" Min="0" HideStep="true" Style="flex: 1 1 0; min-width: 0;" />
-                                        <span class="pool-sep">/</span>
-                                        <FluentNumberField @bind-Value="_editStressMax" Min="0" HideStep="true" Style="flex: 1 1 0; min-width: 0;" />
-                                    </div>
-                                </div>
-                            }
-                            else
-                            {
-                                <div class="chip-pool bg-stress-subtle border-stress">
-                                    <span class="text-stress text-sm">STRESS</span>
-                                    <strong class="text-stress">@_character.Stress.Current / @_character.Stress.Max</strong>
-                                </div>
-                            }
-                        </FluentGridItem>
-                        <FluentGridItem Xs="6" Sm="3">
-                            @if (_isEditing)
-                            {
-                                <div class="pool-edit hope">
-                                    <span class="pool-label">HOPE</span>
-                                    <div class="pool-inputs">
-                                        <FluentNumberField @bind-Value="_editHopeCurrent" Min="0" HideStep="true" Style="flex: 1 1 0; min-width: 0;" />
-                                        <span class="pool-sep">/</span>
-                                        <FluentNumberField @bind-Value="_editHopeMax" Min="0" HideStep="true" Style="flex: 1 1 0; min-width: 0;" />
-                                    </div>
-                                </div>
-                            }
-                            else
-                            {
-                                <div class="chip-pool bg-hope-subtle border-hope">
-                                    <span class="text-hope text-sm">HOPE</span>
-                                    <strong class="text-hope">@_character.Hope.Current / @_character.Hope.Max</strong>
-                                </div>
-                            }
-                        </FluentGridItem>
-                        <FluentGridItem Xs="6" Sm="3">
-                            @if (_isEditing)
-                            {
-                                <div class="pool-edit armor">
-                                    <span class="pool-label">ARMOR</span>
-                                    <div class="pool-inputs">
-                                        <FluentNumberField @bind-Value="_editArmorCurrent" Min="0" HideStep="true" Style="flex: 1 1 0; min-width: 0;" />
-                                        <span class="pool-sep">/</span>
-                                        <FluentNumberField @bind-Value="_editArmorMax" Min="0" HideStep="true" Style="flex: 1 1 0; min-width: 0;" />
-                                    </div>
-                                </div>
-                            }
-                            else
-                            {
-                                <div class="chip-pool card-subtle">
-                                    <span class="text-neutral text-sm">ARMOR</span>
-                                    <strong class="text-neutral">@_character.ArmorSlots.Current / @_character.ArmorSlots.Max</strong>
-                                </div>
-                            }
-                        </FluentGridItem>
-                    </FluentGrid>
-                </div>
+                    <FluentCard>
+                        @* Resource Pools *@
+                        <FluentGrid Spacing="2">
+                            <FluentGridItem Xs="6" Sm="4"> 
+                                <FluentCard class="pool bg-evasion-subtle border-evasion text-positive">
+                                    <div class="text-positive text-sm">EVASION</div>
+                                    <strong>@_character.Evasion</strong>
+                                </FluentCard>
+                            </FluentGridItem>
+                            <FluentGridItem Xs="6" Sm="4">
+                                @if (_isEditing)
+                                {
+                                    <FluentCard class="pool border-hp text-hp">
+                                        <div class="text-hp text-sm">HITPOINTS</div>
+                                        <div class="pool-inputs">
+                                            <FluentNumberField @bind-Value="_editHpCurrent" Min="0" HideStep="true" Style="flex: 1 1 0; min-width: 0;"/>
+                                            <span class="pool-sep">/</span>
+                                            <FluentNumberField @bind-Value="_editHpMax" Min="1" HideStep="true" Style="flex: 1 1 0; min-width: 0;"/>
+                                        </div>
+                                    </FluentCard>
+                                }
+                                else
+                                {
+                                    <FluentCard class="pool bg-hp-subtle border-hp text-hp">
+                                        <div class="text-hp text-sm">HITPOINTS</div>
+                                        <strong>@_character.HitPoints.Current / @_character.HitPoints.Max</strong>
+                                    </FluentCard>
+                                }
+                            </FluentGridItem>
+                            <FluentGridItem Xs="6" Sm="4">
+                                @if (_isEditing)
+                                {
+                                    <FluentCard class="pool border-stress">
+                                        <div class="text-stress text-sm">STRESS</div>
+                                        <div class="pool-inputs">
+                                            <FluentNumberField @bind-Value="_editStressCurrent" Min="0" HideStep="true" Style="flex: 1 1 0; min-width: 0;"/>
+                                            <span class="pool-sep">/</span>
+                                            <FluentNumberField @bind-Value="_editStressMax" Min="0" HideStep="true" Style="flex: 1 1 0; min-width: 0;"/>
+                                        </div>
+                                    </FluentCard>
+                                }
+                                else
+                                {
+                                    <FluentCard class="pool bg-stress-subtle border-stress">
+                                        <div class="text-stress text-sm">STRESS</div>
+                                        <strong class="text-stress">@_character.Stress.Current / @_character.Stress.Max</strong>
+                                    </FluentCard>
+                                }
+                            </FluentGridItem>
+
+                        @* Armor & Damage Thresholds *@
+                            <FluentGridItem Xs="6" Sm="4">
+                                @if (_isEditing)
+                                {
+                                    <FluentCard class="pool border-armor">
+                                        <div class="text-neutral text-sm">ARMOR</div>
+                                        <div class="pool-inputs">
+                                            <FluentNumberField @bind-Value="_editArmorCurrent" Min="0" HideStep="true" Style="flex: 1 1 0; min-width: 0;"/>
+                                            <span class="pool-sep">/</span>
+                                            <FluentNumberField @bind-Value="_editArmorMax" Min="0" HideStep="true" Style="flex: 1 1 0; min-width: 0;"/>
+                                        </div>
+                                    </FluentCard>
+                                }
+                                else
+                                {
+                                    <FluentCard class="pool border-armor-subtle border-armor">
+                                        <div class="text-neutral text-sm">ARMOR</div>
+                                        <strong class="text-neutral">@_character.ArmorSlots.Current / @_character.ArmorSlots.Max</strong>
+                                    </FluentCard>
+                                }
+                            </FluentGridItem>
+                            <FluentGridItem Xs="12" Sm="8">
+                                <FluentCard class="pool" Style="display: flex">
+                                    <FluentStack Style="justify-content: space-between;">
+                                        <div>
+                                            <div class="text-sm">MAJOR THRESHOLD</div>
+                                            <strong>@MajorThreshold</strong>
+                                        </div>
+                                        <FluentDivider Orientation="Orientation.Vertical"/>
+                                        <div>
+                                            <div class="text-sm">SEVERE THRESHOLD</div>
+                                            <strong>@SevereThreshold</strong>
+                                        </div>
+                                    </FluentStack>
+                                </FluentCard>
+                            </FluentGridItem>
+                        
+                        @* Hope with feature *@
+                            <FluentGridItem Xs="4">
+                                @if (_isEditing)
+                                {
+                                    <FluentCard class="pool border-hope">
+                                        <div class="pool-label">HOPE</div>
+                                        <div class="pool-inputs">
+                                            <FluentNumberField @bind-Value="_editHopeCurrent" Min="0" HideStep="true" Style="flex: 1 1 0; min-width: 0;"/>
+                                            <span class="pool-sep">/</span>
+                                            <FluentNumberField @bind-Value="_editHopeMax" Min="0" HideStep="true" Style="flex: 1 1 0; min-width: 0;"/>
+                                        </div>
+                                    </FluentCard>
+                                }
+                                else
+                                {
+                                    <FluentCard class="pool bg-hope-subtle border-hope">
+                                        <div class="text-hope text-sm">HOPE</div>
+                                        <strong class="text-hope">@_character.Hope.Current / @_character.Hope.Max</strong>
+                                    </FluentCard>
+                                }
+                            </FluentGridItem>
+                            <FluentGridItem xs="8">
+
+                                <FluentCard class="pool">
+                                    <div class="text-hope">@_character.GameClass.HopeFeature.Name</div>
+                                    <div class="text-neutral">@_character.GameClass.HopeFeature.Description.ToMarkdownHtml()</div>
+                                </FluentCard>
+                                
+                            </FluentGridItem>
+                        </FluentGrid>
+                    </FluentCard>
 
             </FluentGridItem>
+            @* Traits *@
             <FluentGridItem Xs="12" Sm="6">
-                @* Traits *@
-                <div class="card-section">
+                <FluentCard>
                     <FluentGrid Spacing="1">
                         <FluentGridItem Xs="4" Sm="2">
                             <div class="card-subtle" style="padding:6px 4px;text-align:center;display:flex;flex-direction:column;align-items:center;gap:4px;">
@@ -202,317 +236,333 @@
                                 <strong class="@TraitColorClass(_character.Traits.Knowledge)">@FormatModifier(_character.Traits.Knowledge)</strong>
                             </div>
                         </FluentGridItem>
+                        <FluentGridItem xs="12">
+                            <h4 class="section-title">Proficiency Bonus: +@_character.Proficiency</h4>
+                        </FluentGridItem>
                     </FluentGrid>
-                </div>
+                </FluentCard>
             </FluentGridItem>
-        </FluentGrid>
-
-        @* Two-column grid: Equipment + Abilities *@
-        <div class="content-grid">
-            @* Equipment *@
-            <FluentCard class="section-card">
-                <FluentTabs ActiveTabId="@_equipmentTab" ActiveTabIdChanged="@(v => _equipmentTab = v)">
-                    <FluentTab Id="equipped" Label="Equipped">
-                        <div class="tab-content">
-                            <div class="equipped-view">
-                                <div class="equip-row">
-                                    <span class="equip-label">Proficiency Bonus:</span>
-                                    <span class="equip-value">+@_character.Proficiency</span>
-                                </div>
-                                <div class="equip-row">
-                                    <span class="equip-label">Primary Weapon:</span>
-                                    <span class="equip-value">@(_character.PrimaryWeapon?.Name ?? "None") @FormatWeaponDamage(_character.PrimaryWeapon)</span>
-                                </div>
-                                @if (_character.SecondaryWeapon != null)
-                                {
-                                    <div class="equip-row">
-                                        <span class="equip-label">Secondary Weapon:</span>
-                                        <span class="equip-value">@_character.SecondaryWeapon.Name @FormatWeaponDamage(_character.SecondaryWeapon)</span>
-                                    </div>
-                                }
-                                <div class="equip-row">
-                                    <span class="equip-label">Armor:</span>
-                                    <span class="equip-value">@(_character.EquippedArmor?.Name ?? "None")</span>
-                                </div>
-                            </div>
+            @* Experiences & Abilities *@
+            <FluentGridItem xs="12" sm="6">
+                <FluentGrid Spacing="2">
+                    <FluentGridItem xs="12" sm="12">
+                        <FluentCard>
+                            <div class="section-title">Experiences</div>
                             @if (_isEditing)
                             {
-                                <div class="text-muted divider-section" style="margin-top: 12px;">
-                                    Equip items from the Inventory tab below.
+                                <div class="exp-edit">
+                                    @for (int i = 0; i < _editExperiences.Count; i++)
+                                    {
+                                        var idx = i;
+                                        <div style="display: flex; margin: 5px">
+                                            <FluentTextField @bind-Value="_editExperiences[idx]" Style="width: 100%;"/>
+                                            <FluentButton Appearance="Appearance.Stealth"
+                                                          IconStart="@(new Size20.Delete())"
+                                                          OnClick="@(() => RemoveExperience(idx))"
+                                                          Style="color: var(--dh-negative);"/>
+                                        </div>
+                                    }
+                                    <FluentButton Appearance="Appearance.Accent" OnClick="@AddExperience" Style="margin-top: 8px;">
+                                        Add Experience
+                                    </FluentButton>
                                 </div>
                             }
-                        </div>
-                    </FluentTab>
-                    <FluentTab Id="inventory" Label="Inventory">
-                        <div class="tab-content">
+                            else
+                            {
+                                @if (_character.Experiences.Count > 0)
+                                {
+                                    <FluentStack Wrap="true">
+                                        @foreach (var exp in _character.Experiences)
+                                        {
+                                            <FluentBadge Fill="exp">@exp +2</FluentBadge>
+                                        }
+                                    </FluentStack>
+                                }
+                                else
+                                {
+                                    <div class="text-muted">No experiences</div>
+                                }
+                            }
+                        </FluentCard>
+                    </FluentGridItem>
+                    <FluentGridItem xs="12" sm="12">
+                        <FluentCard>
+                            <div class="section-title">Class Features</div>
+                            @foreach (var cf in _character.GameClass.ClassFeatures)
+                            {
+                                <div class="ability-card">
+                                    <div class="ability-header">
+                                        <span class="ability-name">@cf.Name</span>
+                                         </div>
+                                    <div class="ability-desc">
+                                        @cf.Description.ToMarkdownHtml()
+                                    </div>
+                                </div>
+                            }
+                        </FluentCard>
+                    </FluentGridItem>
+                </FluentGrid>
+            </FluentGridItem>
+            @* Equipment & Inventory *@
+            <FluentGridItem xs="12" sm="6">
+                <FluentGrid Spacing="2">
+                    @* Equipment *@
+                    <FluentGridItem xs="12" sm="12">
+                        <FluentCard>
+                            <div class="section-title">Active Weapons</div>
+                            <div style="border-bottom: 1px solid rgba(255, 255, 255, 0.05); margin-bottom: 5px">
+                                <div class="text-accent">Primary</div>
+                                <FluentStack Style="justify-content: space-between">
+                                    <p>@(_character.PrimaryWeapon?.Name ?? "None")</p>
+                                    <p>@_character.PrimaryWeapon?.Trait</p>
+                                    <p>@_character.PrimaryWeapon?.RangeType</p>
+                                    <p>@FormatWeaponDamage(_character.PrimaryWeapon)</p>
+                                </FluentStack>
+                                <p>@_character.PrimaryWeapon?.Feature</p>
+                            </div>
+                            <div style="border-bottom: 1px solid rgba(255, 255, 255, 0.05); margin-bottom: 5px">
+                                <div class="text-accent">Secondary</div>
+                                <FluentStack Style="justify-content: space-between">
+                                    <p>@(_character.SecondaryWeapon?.Name ?? "None")</p>
+                                    <p>@_character.SecondaryWeapon?.Trait</p>
+                                    <p>@_character.SecondaryWeapon?.RangeType</p>
+                                    <p>@FormatWeaponDamage(_character.SecondaryWeapon)</p>
+                                </FluentStack>
+                                <p>@_character.SecondaryWeapon?.Feature</p>
+                            </div>
+                            <div class="section-title">Active Armor:</div>
+                            <FluentStack Style="justify-content: space-between">
+                                <p>@(_character.EquippedArmor?.Name ?? "None")</p>
+                                <p>@FormatArmorThresholds(_character.EquippedArmor)</p>
+                                <p>Score: @_character.EquippedArmor?.ArmorScore</p>
+                            </FluentStack>
+                            <p>@_character.EquippedArmor?.Feature</p>
+                        </FluentCard>
+                    </FluentGridItem>
+                    @* Inventory *@
+                    <FluentGridItem xs="12" sm="12">
+                        <FluentCard>
+                            <div class="section-title">Inventory</div>
                             @if (_isEditing)
                             {
-                                <div class="inventory-edit">
+                                <FluentStack class="inventory-edit" Orientation="Orientation.Vertical" >
                                     <div class="inventory-row">
-                                        <span class="equip-label">Gold:</span>
-                                        <FluentNumberField @bind-Value="_editGold" Min="0" HideStep="true" Style="width: 80px;" />
+                                        <div class="text-accent">Gold</div>
+                                        <FluentNumberField @bind-Value="_editGold" Min="0" HideStep="true" Style="width: 80px;"/>
                                         <span class="equip-value">handful(s)</span>
                                     </div>
-                                    <div style="margin-top: 12px;">
-                                        <span class="equip-label">Items:</span>
-                                        @for (int i = 0; i < _editInventory.Count; i++)
+                                    <div style="margin-top: 12px; width: inherit">
+                                        <div class="text-accent">Items</div>
+                                        @foreach (var item in _editInventory)
                                         {
-                                            var idx = i;
-                                            var entry = _editInventory[idx];
-                                            <div class="inventory-item-row">
-                                                <span class="inv-item-name @(entry.CatalogId != null ? "inv-match" : "")">@entry.Name</span>
-                                                @if (entry.CatalogId != null)
-                                                {
-                                                    var equipped = IsSlotEquipped(entry.CatalogId.Value, entry.SlotType!);
-                                                    <FluentButton Appearance="@(equipped ? Appearance.Accent : Appearance.Stealth)"
-                                                                   OnClick="@(() => ToggleEquip(idx))"
-                                                                   Style="min-width: 80px;">
-                                                        @(equipped ? "Unequip" : "Equip")
-                                                    </FluentButton>
-                                                }
+                                            <div style="display: flex; ">
+                                                <span class="inv-item-name">@item.Name</span>
                                                 <FluentButton Appearance="Appearance.Stealth"
-                                           IconStart="@(new Size20.Delete())"
-                                                           OnClick="@(() => RemoveInventoryItem(idx))"
-                                                           Style="color: var(--dh-negative);" />
+                                                              IconStart="@(new Size20.Delete())"
+                                                              OnClick="@(() => _editInventory.Remove(item))"
+                                                              Style="color: var(--dh-negative);"/>
                                             </div>
                                         }
                                         <FluentButton Appearance="Appearance.Accent" OnClick="@ShowAddItemPanel" Style="margin-top: 8px;">
                                             Add Item
                                         </FluentButton>
                                     </div>
-                                </div>
+                                </FluentStack>
                             }
                             else
                             {
                                 <div class="inventory-view">
-                                    <div class="equip-row">
-                                        <span class="equip-label">Gold:</span>
+                                    <div class="inventory-section">
+                                        <div class="text-accent">Gold</div>
                                         <span class="equip-value">@_character.GoldHandfuls handful(s)</span>
                                     </div>
-                                    @if (_character.Inventory.Count > 0)
+                                    <div class="inventory-section"> 
+                                        <div class="text-accent">Items</div>
+                                        @if (_character.Inventory.Count > 0)
+                                        {
+                                            <FluentStack Orientation="Orientation.Vertical">
+                                                @foreach (var item in _character.Inventory)
+                                                {
+                                                    <div>@item.Name</div>
+                                                }
+                                            </FluentStack>
+                                        }
+                                        else
+                                        {
+                                            <div class="text-muted" style="margin-top: 8px;">No items</div>
+                                        }
+                                    </div>
+                                </div>
+                            }
+                        </FluentCard>
+                    </FluentGridItem>
+                </FluentGrid>
+                
+            </FluentGridItem>
+            
+            @* Abilities *@
+            <FluentGridItem xs="12" sm="6">
+                <FluentCard>
+                    <div class="section-title">Domain Abilities</div>
+                    @if (_isEditing)
+                    {
+                        @* Available abilities *@
+                        <div class="ability-section">
+                            <div class="ability-section-header">
+                                <span class="text-sm">Available (@(_domainAbilities.Count))</span>
+                            </div>
+                            @if (_domainAbilities.Count > 0)
+                            {
+                                <div class="ability-pick-list">
+                                    @foreach (var ab in _domainAbilities)
                                     {
-                                        <div class="inventory-badges">
-                                            @foreach (var item in _character.Inventory)
-                                            {
-                                                <FluentBadge Appearance="Appearance.Neutral">@item.Name</FluentBadge>
-                                            }
+                                        <div class="ability-entry">
+                                            <div class="ability-info">
+                                                <span class="ability-name">@ab.Title</span>
+                                                <FluentBadge Appearance="Appearance.Neutral">@ab.DomainType · Lv @ab.Level · @ab.Type · Recall @ab.RecallCost</FluentBadge>
+                                            </div>
+                                            <FluentButton Appearance="Appearance.Accent" OnClick="@(() => AddAbility(ab))" Title="Add to active">
+                                                <FluentIcon Value="@(new Size20.ArrowRight())" />
+                                            </FluentButton>
                                         </div>
-                                    }
-                                    else
-                                    {
-                                        <div class="text-muted" style="margin-top: 8px;">No items</div>
                                     }
                                 </div>
                             }
-                        </div>
-                    </FluentTab>
-                </FluentTabs>
-            </FluentCard>
-
-            @* Abilities *@
-            <FluentCard class="section-card">
-                <div class="section-title">Domain Abilities</div>
-                @if (_isEditing)
-                {
-                    @* Available abilities *@
-                    <div class="ability-section">
-                        <div class="ability-section-header">
-                            <span class="text-sm">Available (@(_domainAbilities.Count))</span>
-                        </div>
-                        @if (_domainAbilities.Count > 0)
-                        {
-                            <div class="ability-pick-list">
-                                @foreach (var ab in _domainAbilities)
-                                {
-                                    <div class="ability-entry">
-                                        <div class="ability-info">
-                                            <span class="ability-name">@ab.Title</span>
-                                            <FluentBadge Appearance="Appearance.Neutral">@ab.DomainType · Lv @ab.Level · @ab.Type · Recall @ab.RecallCost</FluentBadge>
-                                        </div>
-                                        <FluentButton Appearance="Appearance.Accent" OnClick="@(() => AddAbility(ab))" Title="Add to active">
-                                            <FluentIcon Value="@(new Size20.ArrowRight())" />
-                                        </FluentButton>
-                                    </div>
-                                }
-                            </div>
-                        }
-                        else
-                        {
-                            <div class="text-muted" style="padding: 8px;">All abilities acquired for your level and domains.</div>
-                        }
-                    </div>
-
-                    @* Active abilities *@
-                    <div class="ability-section">
-                        <div class="ability-section-header">
-                            <span class="text-sm">Active (@(_editActiveAbilities.Count) / 5)</span>
-                        </div>
-                        @if (_editActiveAbilities.Count > 0)
-                        {
-                            <div class="ability-pick-list">
-                                @foreach (var ca in _editActiveAbilities)
-                                {
-                                    <div class="ability-entry">
-                                        <div class="ability-info">
-                                            <span class="ability-name">@ca.Ability.Title</span>
-                                            <FluentBadge Appearance="Appearance.Neutral">@ca.Ability.DomainType · Recall @ca.Ability.RecallCost</FluentBadge>
-                                        </div>
-                                        <FluentButton Appearance="Appearance.Stealth" OnClick="@(() => VaultAbility(ca.AbilityId))" Title="Move to vault">
-                                            <FluentIcon Value="@(new Size20.ArrowDownload())" />
-                                        </FluentButton>
-                                    </div>
-                                }
-                            </div>
-                        }
-                        else
-                        {
-                            <div class="text-muted" style="padding: 8px;">No active abilities.</div>
-                        }
-                    </div>
-
-                    @* Vault *@
-                    <div class="ability-section">
-                        <div class="ability-section-header">
-                            <span class="text-sm">Vault (@(_editVaultAbilities.Count))</span>
-                        </div>
-                        @if (_editVaultAbilities.Count > 0)
-                        {
-                            <div class="ability-pick-list">
-                                @foreach (var ca in _editVaultAbilities)
-                                {
-                                    <div class="ability-entry">
-                                        <div class="ability-info">
-                                            <span class="ability-name">@ca.Ability.Title</span>
-                                            <FluentBadge Appearance="Appearance.Neutral">@ca.Ability.DomainType · Recall @ca.Ability.RecallCost</FluentBadge>
-                                        </div>
-                                        <FluentButton Appearance="Appearance.Stealth" OnClick="@(() => ActivateAbility(ca.AbilityId))" Title="Move to active">
-                                            <FluentIcon Value="@(new Size20.ArrowUpload())" />
-                                        </FluentButton>
-                                    </div>
-                                }
-                            </div>
-                        }
-                        else
-                        {
-                            <div class="text-muted" style="padding: 8px;">Vault is empty.</div>
-                        }
-                    </div>
-                }
-                else
-                {
-                    var activeAbilities = _character.CharacterAbilities.Where(ca => !ca.IsVaulted).ToList();
-                    @if (activeAbilities.Count > 0)
-                    {
-                        <div class="abilities-list">
-                            @foreach (var ca in activeAbilities)
+                            else
                             {
-                                <div class="ability-card">
-                                    <div class="ability-header">
-                                        <span class="ability-name">@ca.Ability.Title</span>
-                                        <FluentBadge Appearance="Appearance.Neutral">@ca.Ability.Type · Recall @ca.Ability.RecallCost</FluentBadge>
-                                    </div>
-                                    <div class="ability-desc">
-                                        @ca.Ability.FeatureDescription.ToMarkdownHtml()
-                                    </div>
+                                <div class="text-muted" style="padding: 8px;">All abilities acquired for your level and domains.</div>
+                            }
+                        </div>
+
+                        @* Active abilities *@
+                        <div class="ability-section">
+                            <div class="ability-section-header">
+                                <span class="text-sm">Active (@(_editActiveAbilities.Count) / 5)</span>
+                            </div>
+                            @if (_editActiveAbilities.Count > 0)
+                            {
+                                <div class="ability-pick-list">
+                                    @foreach (var ca in _editActiveAbilities)
+                                    {
+                                        <div class="ability-entry">
+                                            <div class="ability-info">
+                                                <span class="ability-name">@ca.Ability.Title</span>
+                                                <FluentBadge Appearance="Appearance.Neutral">@ca.Ability.DomainType · Recall @ca.Ability.RecallCost</FluentBadge>
+                                            </div>
+                                            <FluentButton Appearance="Appearance.Stealth" OnClick="@(() => VaultAbility(ca.AbilityId))" Title="Move to vault">
+                                                <FluentIcon Value="@(new Size20.ArrowDownload())" />
+                                            </FluentButton>
+                                        </div>
+                                    }
                                 </div>
+                            }
+                            else
+                            {
+                                <div class="text-muted" style="padding: 8px;">No active abilities.</div>
+                            }
+                        </div>
+
+                        @* Vault *@
+                        <div class="ability-section">
+                            <div class="ability-section-header">
+                                <span class="text-sm">Vault (@(_editVaultAbilities.Count))</span>
+                            </div>
+                            @if (_editVaultAbilities.Count > 0)
+                            {
+                                <div class="ability-pick-list">
+                                    @foreach (var ca in _editVaultAbilities)
+                                    {
+                                        <div class="ability-entry">
+                                            <div class="ability-info">
+                                                <span class="ability-name">@ca.Ability.Title</span>
+                                                <FluentBadge Appearance="Appearance.Neutral">@ca.Ability.DomainType · Recall @ca.Ability.RecallCost</FluentBadge>
+                                            </div>
+                                            <FluentButton Appearance="Appearance.Stealth" OnClick="@(() => ActivateAbility(ca.AbilityId))" Title="Move to active">
+                                                <FluentIcon Value="@(new Size20.ArrowUpload())" />
+                                            </FluentButton>
+                                        </div>
+                                    }
+                                </div>
+                            }
+                            else
+                            {
+                                <div class="text-muted" style="padding: 8px;">Vault is empty.</div>
                             }
                         </div>
                     }
                     else
                     {
-                        <div class="text-muted" style="padding: 20px; text-align: center;">No domain abilities</div>
-                    }
-                }
-            </FluentCard>
-        </div>
-
-        @* Experiences (prominent, full width) *@
-        <FluentCard class="experiences-card">
-            <div class="section-title">Experiences</div>
-            @if (_isEditing)
-            {
-                <div class="exp-edit">
-                    @for (int i = 0; i < _editExperiences.Count; i++)
-                    {
-                        var idx = i;
-                        <div class="exp-edit-row">
-                            <FluentTextField @bind-Value="_editExperiences[idx]" Style="width: 100%;" />
-                            <FluentButton Appearance="Appearance.Stealth"
-                                           IconStart="@(new Size20.Delete())"
-                                           OnClick="@(() => RemoveExperience(idx))"
-                                           Style="color: var(--dh-negative);" />
-                        </div>
-                    }
-                    <FluentButton Appearance="Appearance.Accent" OnClick="@AddExperience" Style="margin-top: 8px;">
-                        Add Experience
-                    </FluentButton>
-                </div>
-            }
-            else
-            {
-                @if (_character.Experiences.Count > 0)
-                {
-                    <div class="exp-list">
-                        @foreach (var exp in _character.Experiences)
+                        var activeAbilities = _character.CharacterAbilities.Where(ca => !ca.IsVaulted).ToList();
+                        @if (activeAbilities.Count > 0)
                         {
-                            <div class="exp-chip-large">
-                                <FluentIcon Value="@(new Size20.Star())" Color="Color.Accent" />
-                                <span>@exp (+2)</span>
-                            </div>
-                        }
-                    </div>
-                }
-                else
-                {
-                    <div class="text-muted">No experiences</div>
-                }
-            }
-        </FluentCard>
-
-        @* Background Questions *@
-        @if (_character.BackgroundAnswers.Any(a => !string.IsNullOrWhiteSpace(a)))
-        {
-            <FluentCard class="section-card full-width">
-                <div class="section-title">Background</div>
-                <div class="bg-list">
-                    @for (int i = 0; i < _character.BackgroundAnswers.Count; i += 2)
-                    {
-                        var question = _character.BackgroundAnswers[i];
-                        var answer = i + 1 < _character.BackgroundAnswers.Count ? _character.BackgroundAnswers[i + 1] : null;
-                        if (!string.IsNullOrWhiteSpace(question))
-                        {
-                            <div class="bg-item">
-                                <div class="bg-question">@question</div>
-                                @if (!string.IsNullOrWhiteSpace(answer))
+                            <div class="abilities-list">
+                                @foreach (var ca in activeAbilities)
                                 {
-                                    <div class="bg-answer">@answer</div>
+                                    <div class="ability-card">
+                                        <div class="ability-header">
+                                            <span class="ability-name">@ca.Ability.Title</span>
+                                            <FluentBadge Appearance="Appearance.Neutral">@ca.Ability.Type · Recall @ca.Ability.RecallCost</FluentBadge>
+                                        </div>
+                                        <div class="ability-desc">
+                                            @ca.Ability.FeatureDescription.ToMarkdownHtml()
+                                        </div>
+                                    </div>
                                 }
                             </div>
                         }
-                    }
-                </div>
-            </FluentCard>
-        }
-
-        @* Description *@
-        @if (DescriptionFields.Any(f => !string.IsNullOrWhiteSpace(f.Value)))
-        {
-            <FluentCard class="section-card full-width">
-                <div class="section-title">Description</div>
-                <div class="desc-grid">
-                    @foreach (var (label, val) in DescriptionFields)
-                    {
-                        if (!string.IsNullOrWhiteSpace(val))
+                        else
                         {
-                            <div class="desc-item">
-                                <span class="desc-label">@label:</span>
-                                <span class="desc-value">@val</span>
-                            </div>
+                            <div class="text-muted" style="padding: 20px; text-align: center;">No domain abilities</div>
                         }
                     }
-                </div>
-            </FluentCard>
-        }
+                </FluentCard>
+            </FluentGridItem>
+ 
+            @* Background Questions *@
+            @if (_character.BackgroundAnswers.Any(a => !string.IsNullOrWhiteSpace(a)))
+            {
+                <FluentCard class="section-card full-width">
+                    <div class="section-title">Background</div>
+                    <div class="bg-list">
+                        @for (int i = 0; i < _character.BackgroundAnswers.Count; i += 2)
+                        {
+                            var question = _character.BackgroundAnswers[i];
+                            var answer = i + 1 < _character.BackgroundAnswers.Count ? _character.BackgroundAnswers[i + 1] : null;
+                            if (!string.IsNullOrWhiteSpace(question))
+                            {
+                                <div class="bg-item">
+                                    <div class="bg-question">@question</div>
+                                    @if (!string.IsNullOrWhiteSpace(answer))
+                                    {
+                                        <div class="bg-answer">@answer</div>
+                                    }
+                                </div>
+                            }
+                        }
+                    </div>
+                </FluentCard>
+            }
+
+            @* Description *@
+            @if (DescriptionFields.Any(f => !string.IsNullOrWhiteSpace(f.Value)))
+            {
+                <FluentCard class="section-card full-width">
+                    <div class="section-title">Description</div>
+                    <div class="desc-grid">
+                        @foreach (var (label, val) in DescriptionFields)
+                        {
+                            if (!string.IsNullOrWhiteSpace(val))
+                            {
+                                <div class="desc-item">
+                                    <span class="desc-label">@label:</span>
+                                    <span class="desc-value">@val</span>
+                                </div>
+                            }
+                        }
+                    </div>
+                </FluentCard>
+            }
+        </FluentGrid>
     }
 </div>
 
@@ -626,10 +676,8 @@
             _character.ArmorSlots = new ResourcePool(_editArmorCurrent, _editArmorMax);
             _character.GoldHandfuls = _editGold;
             _character.Inventory = _editInventory
-                .Where(e => e.SlotType is null)
-                .Select(e => e.CatalogId is not null
-                    ? new Item { Id = e.CatalogId.Value, Name = e.Name, Description = "" }
-                    : new Item { Id = Guid.NewGuid(), Name = e.Name, Description = "" })
+                .Where(e => string.IsNullOrWhiteSpace(e.SlotType))
+                .Select(e => new Item { Id = Guid.NewGuid(), Name = e.Name, Description = "" })
                 .ToList();
             _character.Experiences = _editExperiences;
             _character.EquippedArmorId = _editEquippedArmorId;
@@ -705,21 +753,6 @@
         _errorMessage = string.Empty;
     }
 
-    private void RemoveInventoryItem(int index)
-    {
-        var entry = _editInventory[index];
-        _editInventory.RemoveAt(index);
-        if (entry.CatalogId != null && IsSlotEquipped(entry.CatalogId.Value, entry.SlotType!))
-        {
-            switch (entry.SlotType)
-            {
-                case "Primary": _editPrimaryWeaponId = null; break;
-                case "Secondary": _editSecondaryWeaponId = null; break;
-                case "Armor": _editEquippedArmorId = null; break;
-            }
-        }
-    }
-
     private void AddExperience()
     {
         _editExperiences.Add(string.Empty);
@@ -742,8 +775,14 @@
 
     private string FormatWeaponDamage(Weapon? wp)
     {
-        if (wp == null) return "(0)";
-        return $"({wp.Damage.NumberOfDice}d{wp.Damage.NumberOfSides}{(wp.Damage.Bonus > 0 ? "+" + wp.Damage.Bonus : "")} {wp.Damage.Type})";
+        if (wp == null) return "";
+        return $"{wp.Damage.NumberOfDice}d{wp.Damage.NumberOfSides}{(wp.Damage.Bonus > 0 ? "+" + wp.Damage.Bonus : "")} {wp.Damage.Type}";
+    }
+    
+    private string FormatArmorThresholds(Armor? armor)
+    {
+        if (armor == null) return "";
+        return $"{armor.DamageThresholds.Major} / {armor.DamageThresholds.Severe}";
     }
 
     private bool IsSlotEquipped(Guid catalogId, string slotType)

--- a/Daggerheart-Helper.Shared/Pages/CharacterSheet.razor
+++ b/Daggerheart-Helper.Shared/Pages/CharacterSheet.razor
@@ -525,6 +525,14 @@
     private string _errorMessage = string.Empty;
     private string _equipmentTab = "equipped";
 
+    private int MajorThreshold => _character?.EquippedArmor != null 
+        ? _character.EquippedArmor.DamageThresholds.Major + _character.Level 
+        : _character?.Level ?? 0;
+
+    private int SevereThreshold => _character?.EquippedArmor != null 
+        ? _character.EquippedArmor.DamageThresholds.Severe + _character.Level 
+        : (_character?.Level ?? 0) * 2;
+
     private int _editHpCurrent;
     private int _editHpMax;
     private int _editStressCurrent;

--- a/Daggerheart-Helper.Shared/Pages/CharacterSheet.razor.css
+++ b/Daggerheart-Helper.Shared/Pages/CharacterSheet.razor.css
@@ -1,13 +1,15 @@
-.sheet-container {
-    padding: 30px;
-    background: radial-gradient(circle at top, var(--dh-bg-start) 0%, var(--dh-bg-end) 100%);
-    min-height: 90vh;
-    color: #f0f0f5;
+/* ---- PAGE STRUCTURE ---- */
+.sheet-header {
     display: flex;
-    flex-direction: column;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+}
+
+.content-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
     gap: 20px;
-    max-width: 1100px;
-    margin: 0 auto;
 }
 
 .loading-container {
@@ -38,40 +40,7 @@
     color: #f3f4f6;
 }
 
-/* ---- HEADER ---- */
-.sheet-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-    padding-bottom: 20px;
-}
-
-.header-left {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-}
-
-.header-text h2 {
-    font-size: 2.2rem;
-    margin: 0;
-    background: linear-gradient(135deg, var(--dh-purple) 0%, var(--dh-pink) 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-}
-
-.header-subtitle {
-    font-size: 0.95rem;
-    color: var(--dh-neutral);
-}
-
-.header-actions {
-    display: flex;
-    gap: 8px;
-}
-
-.pool-edit {
+.pool {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -106,23 +75,12 @@
     font-size: 1.1rem;
 }
 
-/* ---- CONTENT GRID ---- */
-.content-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 20px;
-}
-
 .section-card {
     background: rgba(25, 25, 40, 0.55) !important;
     backdrop-filter: blur(10px);
     border: 1px solid rgba(255, 255, 255, 0.06) !important;
     border-radius: 14px;
     padding: 20px;
-}
-
-.section-card.full-width {
-    grid-column: 1 / -1;
 }
 
 .section-title {
@@ -134,20 +92,6 @@
     border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-/* ---- EQUIPPED ---- */
-.equipped-view, .inventory-view {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-}
-
-.equip-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-size: 0.9rem;
-}
-
 .equip-label {
     color: var(--dh-neutral);
     font-weight: 500;
@@ -157,32 +101,8 @@
 .equip-value {
     color: #e5e7eb;
 }
-
-/* ---- INVENTORY ---- */
-.inventory-badges {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px;
-    margin-top: 8px;
-}
-
-.inventory-edit {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-}
-
-.inventory-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-}
-
-.inventory-item-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin-top: 6px;
+.inventory-section {
+    margin: 10px 0;
 }
 
 .inv-item-name {
@@ -201,25 +121,11 @@
     font-size: 0.6rem;
 }
 
-/* ---- ABILITIES ---- */
-.abilities-list {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-}
-
 .ability-card {
     background: rgba(255, 255, 255, 0.02);
     border: 1px solid rgba(255, 255, 255, 0.05);
     border-radius: 10px;
     padding: 14px;
-}
-
-.ability-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 8px;
 }
 
 .ability-name {
@@ -243,44 +149,29 @@
     padding: 20px;
 }
 
-.exp-list {
+.pool-view {
     display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
-}
-
-.exp-chip-large {
-    display: flex;
+    flex-direction: column;
     align-items: center;
-    gap: 8px;
-    background: rgba(56, 189, 248, 0.1);
-    border: 1px solid rgba(56, 189, 248, 0.2);
+    padding: 10px 8px;
     border-radius: 8px;
-    padding: 8px 14px;
+    text-align: center;
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    background: rgba(255, 255, 255, 0.02);
+}
+
+.pool-view.hp { border-color: color-mix(in srgb, var(--dh-hp) 20%, transparent); }
+.pool-view.stress { border-color: color-mix(in srgb, var(--dh-stress) 20%, transparent); }
+.pool-view.hope { border-color: color-mix(in srgb, var(--dh-hope) 20%, transparent); }
+
+.pool-view strong {
     font-size: 0.9rem;
-    color: #7dd3fc;
-    font-weight: 500;
+    color: #e5e7eb;
 }
 
-.exp-edit {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-}
-
-.exp-edit-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin-top: 6px;
-}
-
-/* ---- BACKGROUND ---- */
-.bg-list {
-    display: flex;
-    flex-direction: column;
-    gap: 14px;
-}
+.pool-view.hp strong { color: var(--dh-hp); }
+.pool-view.stress strong { color: var(--dh-stress); }
+.pool-view.hope strong { color: var(--dh-hope); }
 
 .bg-item {
     padding-bottom: 12px;
@@ -305,18 +196,6 @@
     line-height: 1.4;
 }
 
-/* ---- DESCRIPTION ---- */
-.desc-grid {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px 20px;
-}
-
-.desc-item {
-    display: flex;
-    gap: 4px;
-}
-
 .desc-label {
     color: var(--dh-neutral);
     font-weight: 500;
@@ -327,9 +206,5 @@
     font-style: italic;
 }
 
-/* ---- TAB CONTENT ---- */
-.tab-content {
-    padding-top: 16px;
-}
 
 

--- a/Daggerheart-Helper.Shared/Pages/Characters.razor
+++ b/Daggerheart-Helper.Shared/Pages/Characters.razor
@@ -5,15 +5,11 @@
 
 <PageTitle>My Characters</PageTitle>
 
-<div class="dashboard-container">
-    <div class="dashboard-header">
-        <div class="header-text">
-            <h2>My Characters</h2>
-        </div>
-        <FluentButton Appearance="Appearance.Accent" IconStart="@(new Icons.Filled.Size20.PersonAdd())" @onClick="CreateNew">
-            Create new character
-        </FluentButton>
-    </div>
+<PageHeader Title="My Characters">
+    <FluentButton Appearance="Appearance.Accent" IconStart="@(new Icons.Filled.Size20.PersonAdd())" @onclick="CreateNew">
+        Create new character
+    </FluentButton>
+</PageHeader>
 
     @if (_loading)
     {
@@ -35,142 +31,42 @@
     }
     else
     {
-        <div class="character-grid animate-fade">
+        <FluentGrid Spacing="3" Class="animate-fade">
             @foreach (var ch in _characters)
             {
-                <div class="character-card" @onclick="@(() => NavigateTo(ch.Id))" @onclick:stopPropagation>
-                    <div class="card-accent"></div>
-                    <div class="card-header">
-                        <div class="char-title">
-                            <h3>@ch.Name</h3>
-                            <span class="char-class">Level @ch.Level @ch.GameClass.Name (@ch.Subclass.Name)</span>
-                        </div>
-                        <span @onclick:stopPropagation>
-                            <FluentButton
-                                Appearance="Appearance.Stealth" 
-                                IconStart="@(new Icons.Filled.Size20.Eye())" 
-                                OnClick="@(() => NavigationManager.NavigateTo($"/QuickView/{ch.Id}"))" 
-                                Title="Quick View"
-                                Style="color: var(--dh-neutral); margin-right: 4px;" />
-                        </span>
-                        <span @onclick:stopPropagation>
-                            <FluentButton
-                                Appearance="Appearance.Stealth" 
-                                IconStart="@(new Icons.Filled.Size20.Delete())" 
-                                OnClick="@(() => ConfirmDelete(ch.Id))" 
-                                Disabled="@_isDeleting"
-                                Title="Delete character"
-                                Style="color: var(--dh-negative);" />
-                        </span>
-                    </div>
+                <FluentGridItem xs="12" sm="6" lg="4" xl="3">
+                    <div>
+                        <FluentCard Class="character-card" @onclick="@(() => NavigateTo(ch.Id))"> 
+                            <CardHeader Title="@ch.Name" Subtitle="@($"Level {ch.Level} {ch.Subclass.Name} {ch.GameClass.Name} {ch.Community.Name} {ch.Ancestry.Name}")">
+                                <span @onclick:stopPropagation>
+                                    <FluentButton
+                                        Appearance="Appearance.Stealth" 
+                                        IconStart="@(new Icons.Filled.Size20.Delete())" 
+                                        OnClick="@(() => ConfirmDelete(ch.Id))" 
+                                        Disabled="@_isDeleting"
+                                        Title="Delete character"
+                                        Style="color: var(--dh-negative);" />
+                                </span>
+                            </CardHeader>
 
-                    <div class="card-body">
-                        <!-- Heritage -->
-                        <div class="meta-section">
-                            <span class="meta-label">Heritage:</span>
-                            <span class="meta-val">@ch.Ancestry.Name, @ch.Community.Name</span>
-                        </div>
-
-                        <!-- Stats Pools -->
-                        <div class="pools-grid">
-                            <div class="pool-badge hp">
-                                <span class="pool-name">Hitpoints</span>
-                                <span class="pool-val">@ch.HitPoints.Current / @ch.HitPoints.Max</span>
-                            </div>
-                            <div class="pool-badge stress">
-                                <span class="pool-name">Stress</span>
-                                <span class="pool-val">@ch.Stress.Current / @ch.Stress.Max</span>
-                            </div>
-                            <div class="pool-badge hope">
-                                <span class="pool-name">Hope</span>
-                                <span class="pool-val">@ch.Hope.Current / @ch.Hope.Max</span>
-                            </div>
-                            <div class="pool-badge armor-slots">
-                                <span class="pool-name">Armor</span>
-                                <span class="pool-val">@ch.ArmorSlots.Current / @ch.ArmorSlots.Max</span>
-                            </div>
-                        </div>
-
-                        <!-- Calculated Stats -->
-                        <div class="combat-stats">
-                            <div class="combat-stat">
-                                <strong>@ch.Evasion</strong>
-                                <span>Evasion</span>
-                            </div>
-                            <div class="combat-stat">
-                                <strong>@(ch.EquippedArmor?.ArmorScore ?? 0)</strong>
-                                <span>Armor Score</span>
-                            </div>
-                            <div class="combat-stat thresholds">
-                                <strong>@ch.DamageThresholds.Major / @ch.DamageThresholds.Severe</strong>
-                                <span>Damage Thresholds (Major/Severe)</span>
-                            </div>
-                        </div>
-
-                        <!-- Traits -->
-                        <div class="traits-summary">
-                            <div class="trait-chip">AGILITY <span>@FormatVal(ch.Traits.Agility)</span></div>
-                            <div class="trait-chip">STRENGTH <span>@FormatVal(ch.Traits.Strength)</span></div>
-                            <div class="trait-chip">FINESSE <span>@FormatVal(ch.Traits.Finesse)</span></div>
-                            <div class="trait-chip">INSTINCT <span>@FormatVal(ch.Traits.Instinct)</span></div>
-                            <div class="trait-chip">PRESENCE <span>@FormatVal(ch.Traits.Presence)</span></div>
-                            <div class="trait-chip">KNOWLEDGE <span>@FormatVal(ch.Traits.Knowledge)</span></div>
-                        </div>
-
-                        <!-- Equipment -->
-                        <div class="gear-section">
-                            <strong>Equipment:</strong>
-                            <div class="gear-item">
-                                <FluentIcon Value="@(new Icons.Filled.Size16.Shield())" Color="Color.Accent" />
-                                <span>Armor: @(ch.EquippedArmor?.Name ?? "No armor")</span>
-                            </div>
-                            <div class="gear-item">
-                                <FluentIcon Value="@(new Icons.Filled.Size16.Flash())" Color="Color.Accent" />
-                                <span>Primary: @(ch.PrimaryWeapon?.Name ?? "No weapon") (@FormatWeaponDamage(ch.PrimaryWeapon))</span>
-                            </div>
-                            @if (ch.SecondaryWeapon != null)
-                            {
-                                <div class="gear-item">
-                                    <FluentIcon Value="@(new Icons.Filled.Size16.Flash())" Color="Color.Accent" />
-                                    <span>Secondary: @ch.SecondaryWeapon.Name (@FormatWeaponDamage(ch.SecondaryWeapon))</span>
-                                </div>
-                            }
-                        </div>
-
-                        <!-- Experiences -->
-                        @if (ch.Experiences.Count > 0)
-                        {
-                            <div class="exp-section">
-                                <strong>Experiences:</strong>
-                                <div class="exp-list">
-                                    @foreach (var exp in ch.Experiences)
-                                    {
-                                        <span class="exp-chip">@exp (+2)</span>
-                                    }
-                                </div>
-                            </div>
-                        }
-
-                        <!-- Background -->
-                        @if (ch.BackgroundAnswers.Any(a => !string.IsNullOrWhiteSpace(a)))
-                        {
-                            <div class="bg-section">
-                                <strong>Background:</strong>
-                                @for (int i = 0; i < ch.BackgroundAnswers.Count; i++)
+                        <div class="card-body">
+                            <div class="quick-stats">
+                                <FluentBadge Fill="hp">@ch.HitPoints.Current/@ch.HitPoints.Max HP</FluentBadge>
+                                <FluentBadge Fill="stress">@ch.Stress.Current/@ch.Stress.Max Stress</FluentBadge>
+                                <FluentBadge Fill="hope">@ch.Hope.Current/@ch.Hope.Max Hope</FluentBadge>
+                                <FluentBadge Fill="evasion">Evasion @ch.Evasion</FluentBadge>
+                                @if (ch.EquippedArmor != null) 
                                 {
-                                    if (!string.IsNullOrWhiteSpace(ch.BackgroundAnswers[i]))
-                                    {
-                                        <p class="bg-answer">@ch.BackgroundAnswers[i]</p>
-                                    }
+                                    <FluentBadge Fill="armor">Armor @ch.EquippedArmor.ArmorScore</FluentBadge>
                                 }
                             </div>
-                        }
+                        </div>
+                    </FluentCard>
                     </div>
-                </div>
+                </FluentGridItem>
             }
-        </div>
+        </FluentGrid>
     }
-</div>
 
 @code {
     private List<Character> _characters = new();
@@ -238,14 +134,4 @@
         NavigationManager.NavigateTo($"/character/{id}");
     }
 
-    private string FormatVal(int val)
-    {
-        return val >= 0 ? $"+{val}" : val.ToString();
-    }
-
-    private string FormatWeaponDamage(Weapon? wp)
-    {
-        if (wp == null) return "0";
-        return $"{wp.Damage.NumberOfDice}d{wp.Damage.NumberOfSides}{(wp.Damage.Bonus > 0 ? "+" + wp.Damage.Bonus : "")} {wp.Damage.Type}";
-    }
 }

--- a/Daggerheart-Helper.Shared/Pages/Characters.razor.css
+++ b/Daggerheart-Helper.Shared/Pages/Characters.razor.css
@@ -1,33 +1,3 @@
-.dashboard-container {
-    padding: 30px;
-    background: radial-gradient(circle at top, var(--dh-bg-start) 0%, var(--dh-bg-end) 100%);
-    min-height: 90vh;
-    color: #f0f0f5;
-}
-
-.dashboard-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 30px;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-    padding-bottom: 20px;
-}
-
-.header-text h2 {
-    font-size: 2.2rem;
-    margin: 0 0 5px 0;
-    background: linear-gradient(135deg, var(--dh-purple) 0%, var(--dh-pink) 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-}
-
-.header-text p {
-    margin: 0;
-    color: var(--dh-neutral);
-    font-size: 0.95rem;
-}
-
 .loading-container {
     display: flex;
     flex-direction: column;
@@ -64,251 +34,39 @@
     max-width: 400px;
 }
 
-.character-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
-    gap: 25px;
+.card-accent {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    z-index: 1;
+    border-radius: 14px 14px 0 0;
+    background: linear-gradient(90deg, var(--dh-purple), var(--dh-pink));
 }
 
-.character-card {
-    background: rgba(25, 25, 40, 0.55);
-    backdrop-filter: blur(10px);
-    border: 1px solid rgba(255, 255, 255, 0.06);
-    border-radius: 14px;
-    overflow: hidden;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+::deep fluent-card.character-card {
+    cursor: pointer;
     transition: all 0.25s ease;
     display: flex;
     flex-direction: column;
-    cursor: pointer;
 }
 
-.character-card:hover {
+::deep fluent-card.character-card:hover {
     transform: translateY(-3px);
     border-color: color-mix(in srgb, var(--dh-purple) 25%, transparent);
     box-shadow: 0 12px 30px color-mix(in srgb, var(--dh-purple) 10%, transparent);
 }
 
-.card-accent {
-    height: 4px;
-    background: linear-gradient(90deg, var(--dh-purple), var(--dh-pink));
-}
-
-.card-header {
-    padding: 20px 20px 15px 20px;
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
-}
-
-.char-title h3 {
-    margin: 0 0 4px 0;
-    font-size: 1.35rem;
-    color: #f9fafb;
-}
-
-.char-class {
-    font-size: 0.82rem;
-    color: var(--dh-purple);
-    font-weight: 500;
-}
-
 .card-body {
-    padding: 20px;
     display: flex;
     flex-direction: column;
-    gap: 15px;
+    gap: 10px;
 }
 
-.meta-section {
-    font-size: 0.88rem;
-}
-
-.meta-label {
-    color: var(--dh-neutral);
-    margin-right: 5px;
-}
-
-.meta-val {
-    color: #e5e7eb;
-    font-weight: 500;
-}
-
-.pools-grid {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 8px;
-}
-
-.pool-badge {
+.quick-stats {
     display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 6px 4px;
-    border-radius: 6px;
-    background: rgba(255, 255, 255, 0.02);
-    border: 1px solid rgba(255, 255, 255, 0.04);
-    text-align: center;
-}
-
-.pool-name {
-    font-size: 0.65rem;
-    font-weight: 600;
-    letter-spacing: 1px;
-    margin-bottom: 2px;
-}
-
-.pool-val {
-    font-size: 0.8rem;
-    font-weight: bold;
-}
-
-.pool-badge.hp { color: var(--dh-hp); border-color: color-mix(in srgb, var(--dh-hp) 20%, transparent); background: color-mix(in srgb, var(--dh-hp) 5%, transparent); }
-.pool-badge.stress { color: var(--dh-stress); border-color: color-mix(in srgb, var(--dh-stress) 20%, transparent); background: color-mix(in srgb, var(--dh-stress) 5%, transparent); }
-.pool-badge.hope { color: var(--dh-hope); border-color: color-mix(in srgb, var(--dh-hope) 20%, transparent); background: color-mix(in srgb, var(--dh-hope) 5%, transparent); }
-.pool-badge.armor-slots { color: var(--dh-neutral); border-color: color-mix(in srgb, var(--dh-neutral) 20%, transparent); background: color-mix(in srgb, var(--dh-neutral) 5%, transparent); }
-
-.combat-stats {
-    display: flex;
-    justify-content: space-around;
-    background: rgba(255, 255, 255, 0.02);
-    border: 1px solid rgba(255, 255, 255, 0.04);
-    border-radius: 8px;
-    padding: 10px 5px;
-}
-
-.combat-stat {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    text-align: center;
-    flex: 1;
-}
-
-.combat-stat:not(:last-child) {
-    border-right: 1px solid rgba(255, 255, 255, 0.05);
-}
-
-.combat-stat strong {
-    font-size: 1.15rem;
-    color: #f3f4f6;
-}
-
-.combat-stat span {
-    font-size: 0.7rem;
-    color: var(--dh-neutral);
-    margin-top: 2px;
-}
-
-.combat-stat.thresholds strong {
-    font-size: 0.95rem;
-    line-height: 1.4;
-}
-
-.traits-summary {
-    display: grid;
-    grid-template-columns: repeat(6, 1fr);
+    flex-wrap: wrap;
     gap: 4px;
 }
 
-.trait-chip {
-    font-size: 0.65rem;
-    font-weight: 600;
-    background: rgba(255, 255, 255, 0.03);
-    border: 1px solid rgba(255, 255, 255, 0.05);
-    border-radius: 4px;
-    padding: 4px 2px;
-    text-align: center;
-    color: var(--dh-neutral);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-}
-
-.trait-chip span {
-    font-size: 0.8rem;
-    font-weight: bold;
-    color: #f3f4f6;
-    margin-top: 2px;
-}
-
-.gear-section {
-    border-top: 1px solid rgba(255, 255, 255, 0.05);
-    padding-top: 12px;
-    font-size: 0.8rem;
-}
-
-.gear-section strong {
-    color: var(--dh-neutral);
-    display: block;
-    margin-bottom: 6px;
-}
-
-.gear-item {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin-top: 4px;
-    color: #cbd5e1;
-}
-
-.gear-item span {
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
-}
-
-.exp-section {
-    border-top: 1px solid rgba(255, 255, 255, 0.05);
-    padding-top: 12px;
-    font-size: 0.8rem;
-}
-
-.exp-section strong {
-    color: var(--dh-neutral);
-    display: block;
-    margin-bottom: 6px;
-}
-
-.exp-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px;
-}
-
-.exp-chip {
-    background: rgba(56, 189, 248, 0.1);
-    border: 1px solid rgba(56, 189, 248, 0.2);
-    border-radius: 4px;
-    padding: 3px 8px;
-    font-size: 0.75rem;
-    color: #7dd3fc;
-}
-
-.bg-section {
-    border-top: 1px solid rgba(255, 255, 255, 0.05);
-    padding-top: 12px;
-    font-size: 0.8rem;
-}
-
-.bg-section strong {
-    color: var(--dh-neutral);
-    display: block;
-    margin-bottom: 6px;
-}
-
-.bg-answer {
-    color: #cbd5e1;
-    margin: 2px 0;
-    line-height: 1.4;
-}
-
-.animate-fade {
-    animation: fadeIn 0.3s ease-out;
-}
-
-@keyframes fadeIn {
-    from { opacity: 0; transform: translateY(5px); }
-    to { opacity: 1; transform: translateY(0); }
-}

--- a/Daggerheart-Helper.Shared/Pages/DM-tools.razor
+++ b/Daggerheart-Helper.Shared/Pages/DM-tools.razor
@@ -16,11 +16,10 @@
             <p>Browse and search all adversaries from the SRD. Filter by type, tier, and difficulty.</p>
         </div>
 
-        <div class="tool-card disabled">
-            <FluentIcon Value="@(new Icons.Filled.Size20.BookOpen())" Color="Color.Neutral" />
-            <h3>SRD Reference</h3>
-            <p>Browse abilities, items, ancestries, and more from the SRD.</p>
-            <span class="coming-soon">Coming soon</span>
+        <div class="tool-card" @onclick="GoToReferenceCatalog">
+            <FluentIcon Value="@(new Icons.Filled.Size20.BookOpen())" Color="Color.Accent" />
+            <h3>Reference Catalog</h3>
+            <p>Browse abilities, items, ancestries, classes, armor, and weapons from the SRD.</p>
         </div>
 
         <div class="tool-card disabled">
@@ -36,5 +35,10 @@
     private void GoToAdversaries()
     {
         NavigationManager.NavigateTo("/dm-tools/adversaries");
+    }
+
+    private void GoToReferenceCatalog()
+    {
+        NavigationManager.NavigateTo("/dm-tools/reference-catalog");
     }
 }

--- a/Daggerheart-Helper.Shared/Pages/DM-tools.razor
+++ b/Daggerheart-Helper.Shared/Pages/DM-tools.razor
@@ -1,35 +1,38 @@
 @page "/dm-tools"
 @inject NavigationManager NavigationManager
 
-<div class="dashboard-container">
-    <div class="dashboard-header">
-        <div class="header-text">
-            <h2>DM Tools</h2>
-            <p>Resources and references for Game Masters</p>
-        </div>
-    </div>
+<PageHeader Title="DM Tools" Subtitle="Resources and references for Game Masters" />
 
-    <div class="tools-grid animate-fade">
-        <div class="tool-card" @onclick="GoToAdversaries">
-            <FluentIcon Value="@(new Icons.Filled.Size20.PersonLightning())" Color="Color.Accent" />
-            <h3>Adversary Browser</h3>
-            <p>Browse and search all adversaries from the SRD. Filter by type, tier, and difficulty.</p>
+<FluentGrid>
+    <FluentGridItem xs="12" sm="12" md="4" lg="4">
+        <div>
+            <FluentCard Class="tool-card" @onclick="GoToAdversaries">
+                <FluentIcon Value="@(new Icons.Filled.Size20.PersonLightning())" Color="Color.Accent"/>
+                <h3>Adversary Browser</h3>
+                <p>Browse and search all adversaries from the SRD. Filter by type, tier, and difficulty.</p>
+            </FluentCard>
         </div>
-
-        <div class="tool-card" @onclick="GoToReferenceCatalog">
-            <FluentIcon Value="@(new Icons.Filled.Size20.BookOpen())" Color="Color.Accent" />
-            <h3>Reference Catalog</h3>
-            <p>Browse abilities, items, ancestries, classes, armor, and weapons from the SRD.</p>
+    </FluentGridItem>
+    <FluentGridItem xs="12" sm="12" md="4" lg="4">
+        <div>
+            <FluentCard Class="tool-card" @onclick="GoToReferenceCatalog">  
+                <FluentIcon Value="@(new Icons.Filled.Size20.BookOpen())" Color="Color.Accent"/>
+                <h3>Reference Catalog</h3>
+                <p>Browse abilities, items, ancestries, classes, armor, and weapons from the SRD.</p>
+            </FluentCard>
         </div>
-
-        <div class="tool-card disabled">
-            <FluentIcon Value="@(new Icons.Filled.Size20.Globe())" Color="Color.Neutral" />
-            <h3>Encounter Builder</h3>
-            <p>Build balanced encounters using adversary tier and difficulty ratings.</p>
-            <span class="coming-soon">Coming soon</span>
+    </FluentGridItem>
+    <FluentGridItem xs="12" sm="12" md="4" lg="4">
+        <div>
+            <FluentCard Class="tool-card disabled">
+                <FluentIcon Value="@(new Icons.Filled.Size20.Globe())" Color="Color.Neutral"/>
+                <h3>Encounter Builder</h3>
+                <p>Build balanced encounters using adversary tier and difficulty ratings.</p>
+                <span class="coming-soon">Coming soon</span>
+            </FluentCard>
         </div>
-    </div>
-</div>
+    </FluentGridItem>
+</FluentGrid>
 
 @code {
     private void GoToAdversaries()

--- a/Daggerheart-Helper.Shared/Pages/DM-tools.razor.css
+++ b/Daggerheart-Helper.Shared/Pages/DM-tools.razor.css
@@ -1,38 +1,4 @@
-.dashboard-container {
-    padding: 30px;
-    background: radial-gradient(circle at top, var(--dh-bg-start) 0%, var(--dh-bg-end) 100%);
-    min-height: 90vh;
-    color: #f0f0f5;
-}
-
-.dashboard-header {
-    margin-bottom: 30px;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-    padding-bottom: 20px;
-}
-
-.header-text h2 {
-    font-size: 2.2rem;
-    margin: 0 0 5px 0;
-    background: linear-gradient(135deg, var(--dh-purple) 0%, var(--dh-pink) 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-}
-
-.header-text p {
-    margin: 0;
-    color: var(--dh-neutral);
-    font-size: 0.95rem;
-}
-
-.tools-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-    gap: 20px;
-}
-
-.tool-card {
-    background: rgba(25, 25, 40, 0.55);
+::deep fluent-card.tool-card {
     backdrop-filter: blur(10px);
     border: 1px solid rgba(255, 255, 255, 0.06);
     border-radius: 14px;
@@ -40,30 +6,29 @@
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
     transition: all 0.25s ease;
     cursor: pointer;
-    display: flex;
     flex-direction: column;
     align-items: flex-start;
     gap: 12px;
 }
 
-.tool-card:not(.disabled):hover {
+::deep fluent-card.tool-card:not(.disabled):hover {
     transform: translateY(-3px);
     border-color: color-mix(in srgb, var(--dh-purple) 25%, transparent);
     box-shadow: 0 12px 30px color-mix(in srgb, var(--dh-purple) 10%, transparent);
 }
 
-.tool-card.disabled {
+::deep fluent-card.tool-card.disabled {
     opacity: 0.45;
     cursor: default;
 }
 
-.tool-card h3 {
+::deep fluent-card.tool-card h3 {
     margin: 0;
     font-size: 1.2rem;
     color: #f9fafb;
 }
 
-.tool-card p {
+::deep fluent-card.tool-card p {
     margin: 0;
     font-size: 0.88rem;
     color: var(--dh-neutral);
@@ -82,11 +47,3 @@
     border-radius: 8px;
 }
 
-.animate-fade {
-    animation: fadeIn 0.3s ease-out;
-}
-
-@keyframes fadeIn {
-    from { opacity: 0; transform: translateY(5px); }
-    to { opacity: 1; transform: translateY(0); }
-}

--- a/Daggerheart-Helper.Shared/Pages/Home.razor
+++ b/Daggerheart-Helper.Shared/Pages/Home.razor
@@ -3,31 +3,30 @@
 
 <PageTitle>Home</PageTitle>
 
-<FluentLayout Style="display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100%;">
-    <FluentStack Orientation="Orientation.Vertical"
-                 HorizontalAlignment="HorizontalAlignment.Center"
-                 VerticalAlignment="VerticalAlignment.Center"
-                 Width="300"
-                 VerticalGap="10">
-        <FluentButton Appearance="Appearance.Accent"
-                      IconStart="@(new Icons.Filled.Size20.PersonAdd())"
-                      OnClick="@(() => NavigationManager.NavigateTo("/CharacterCreator"))"
-                      Style="width: 100%;">
-            Create Character
-        </FluentButton>
-        <FluentButton Appearance="Appearance.Accent"
-                      IconStart="@(new Icons.Filled.Size20.PeopleCommunity())"
-                      OnClick="@(() => NavigationManager.NavigateTo("/Characters"))"
-                      Style="width: 100%;">
-            My Characters
-        </FluentButton>
-        <FluentButton Appearance="Appearance.Accent"
-                      IconStart="@(new Icons.Filled.Size20.PersonLightning())"
-                      OnClick="@(() => NavigationManager.NavigateTo("/dm-tools"))"
-                      Style="width: 100%;">
-            DM Tools
-        </FluentButton>
-    </FluentStack>
-</FluentLayout>
+<FluentStack Orientation="Orientation.Vertical"
+             HorizontalAlignment="HorizontalAlignment.Center"
+             VerticalAlignment="VerticalAlignment.Center"
+             Width="300"
+             VerticalGap="10"
+             Style="min-height: 60vh;">
+    <FluentButton Appearance="Appearance.Accent"
+                  IconStart="@(new Icons.Filled.Size20.PersonAdd())"
+                  OnClick="@(() => NavigationManager.NavigateTo("/CharacterCreator"))"
+                  Style="width: 100%;">
+        Create Character
+    </FluentButton>
+    <FluentButton Appearance="Appearance.Accent"
+                  IconStart="@(new Icons.Filled.Size20.PeopleCommunity())"
+                  OnClick="@(() => NavigationManager.NavigateTo("/Characters"))"
+                  Style="width: 100%;">
+        My Characters
+    </FluentButton>
+    <FluentButton Appearance="Appearance.Accent"
+                  IconStart="@(new Icons.Filled.Size20.PersonLightning())"
+                  OnClick="@(() => NavigationManager.NavigateTo("/dm-tools"))"
+                  Style="width: 100%;">
+        DM Tools
+    </FluentButton>
+</FluentStack>
 
 

--- a/Daggerheart-Helper.Shared/Pages/ReferenceCatalog.razor
+++ b/Daggerheart-Helper.Shared/Pages/ReferenceCatalog.razor
@@ -1,0 +1,382 @@
+@page "/dm-tools/reference-catalog"
+@inject IAbilityCatalogQueries AbilityQueries
+@inject IItemCatalogQueries ItemQueries
+@inject IHeritageCatalogQueries HeritageQueries
+@inject IClassCatalogQueries ClassQueries
+@inject IArmorCatalogQueries ArmorQueries
+@inject IWeaponCatalogQueries WeaponQueries
+@inject NavigationManager NavigationManager
+
+<div class="dashboard-container">
+    <div class="dashboard-header">
+        <FluentAnchor Href="/dm-tools" Appearance="Appearance.Hypertext">
+            <FluentIcon Value="@(new Icons.Filled.Size20.ArrowLeft())" /> Back to DM Tools
+        </FluentAnchor>
+        <div class="header-text">
+            <h2>Reference Catalog</h2>
+            <p>Browse all SRD reference data</p>
+        </div>
+    </div>
+
+    @if (_loading)
+    {
+        <FluentProgressRing />
+    }
+    else
+    {
+        <FluentStack Orientation="Orientation.Horizontal" Wrap="true" Class="tab-bar">
+            @foreach (var tab in _tabs)
+            {
+                <FluentButton Appearance="@(_activeTab == tab.Key ? Appearance.Accent : Appearance.Neutral)"
+                              OnClick="@(() => _activeTab = tab.Key)">
+                    @tab.Label
+                </FluentButton>
+            }
+        </FluentStack>
+
+        @* Abilities *@
+        <div class="tab-content" style="display: @(_activeTab == 0 ? null : "none")">
+            <FluentTextField Placeholder="Search by name..." Value="@_abilitySearch" Immediate ImmediateDelay="200" ValueChanged="@(v => { _abilitySearch = v; _abilityItems = FilterAbilities().AsQueryable(); StateHasChanged(); })" />
+            <FluentDataGrid Items="@_abilityItems" GridTemplateColumns="1fr 100px 80px 100px 80px 80px">
+                <PropertyColumn Property="@(a => a.Title)" Title="Name" Sortable="true" />
+                <PropertyColumn Property="@(a => a.DomainType)" Title="Domain" Sortable="true" />
+                <TemplateColumn Title="Level" Sortable="true" Align="Align.Center" SortBy="GridSort<Ability>.ByAscending(a => a.Level)">
+                    <FluentBadge>@context.Level</FluentBadge>
+                </TemplateColumn>
+                <PropertyColumn Property="@(a => a.Type)" Title="Type" Sortable="true" />
+                <TemplateColumn Title="Recall" Align="Align.Center">
+                    <FluentBadge Fill="@(context.RecallCost > 0 ? "recall" : "none")">@(context.RecallCost > 0 ? $"{context.RecallCost}" : "—")</FluentBadge>
+                </TemplateColumn>
+                <TemplateColumn Title="">
+                    <FluentButton Appearance="Appearance.Lightweight" OnClick="@(() => _selectedAbility = context)">View</FluentButton>
+                </TemplateColumn>
+            </FluentDataGrid>
+            @if (_selectedAbility is not null)
+            {
+                <div class="detail-section">
+                    <FluentCard Class="detail-card">
+                        <div class="detail-header">
+                            <h3>@_selectedAbility.Title</h3>
+                            <FluentButton Appearance="Appearance.Lightweight" OnClick="@(() => _selectedAbility = null)">
+                                <FluentIcon Value="@(new Icons.Regular.Size20.Dismiss())" />
+                            </FluentButton>
+                        </div>
+                        <div class="detail-stats">
+                            <span><strong>Domain:</strong> @_selectedAbility.DomainType</span>
+                            <span><strong>Level:</strong> @_selectedAbility.Level</span>
+                            <span><strong>Recall:</strong> @_selectedAbility.RecallCost</span>
+                            <span><strong>Type:</strong> @_selectedAbility.Type</span>
+                        </div>
+                        <p>@_selectedAbility.FeatureDescription</p>
+                    </FluentCard>
+                </div>
+            }
+        </div>
+
+        @* Items *@
+        <div class="tab-content" style="display: @(_activeTab == 1 ? null : "none")">
+            <FluentTextField Placeholder="Search by name..." Value="@_itemSearch" Immediate ImmediateDelay="200" ValueChanged="@(v => { _itemSearch = v; _itemItems = FilterItems().AsQueryable(); StateHasChanged(); })" />
+            <FluentDataGrid Items="@_itemItems" GridTemplateColumns="1fr 2fr 80px">
+                <PropertyColumn Property="@(i => i.Name)" Title="Name" Sortable="true" />
+                <PropertyColumn Property="@(i => i.Description)" Title="Description" />
+                <TemplateColumn Title="">
+                    <FluentButton Appearance="Appearance.Lightweight" OnClick="@(() => _selectedItem = context)">View</FluentButton>
+                </TemplateColumn>
+            </FluentDataGrid>
+            @if (_selectedItem is not null)
+            {
+                <div class="detail-section">
+                    <FluentCard Class="detail-card">
+                        <div class="detail-header">
+                            <h3>@_selectedItem.Name</h3>
+                            <FluentButton Appearance="Appearance.Lightweight" OnClick="@(() => _selectedItem = null)">
+                                <FluentIcon Value="@(new Icons.Regular.Size20.Dismiss())" />
+                            </FluentButton>
+                        </div>
+                        <p>@_selectedItem.Description</p>
+                    </FluentCard>
+                </div>
+            }
+        </div>
+
+        @* Ancestries *@
+        <div class="tab-content" style="display: @(_activeTab == 2 ? null : "none")">
+            <FluentTextField Placeholder="Search by name..." Value="@_ancestrySearch" Immediate ImmediateDelay="200" ValueChanged="@(v => { _ancestrySearch = v; _ancestryItems = FilterAncestries().AsQueryable(); StateHasChanged(); })" />
+            <FluentDataGrid Items="@_ancestryItems" GridTemplateColumns="1fr 100px 80px">
+                <PropertyColumn Property="@(a => a.Name)" Title="Name" Sortable="true" />
+                <TemplateColumn Title="Features">
+                    @string.Join(", ", context.Features.Select(f => f.Name))
+                </TemplateColumn>
+                <TemplateColumn Title="">
+                    <FluentButton Appearance="Appearance.Lightweight" OnClick="@(() => _selectedAncestry = context)">View</FluentButton>
+                </TemplateColumn>
+            </FluentDataGrid>
+            @if (_selectedAncestry is not null)
+            {
+                <div class="detail-section">
+                    <FluentCard Class="detail-card">
+                        <div class="detail-header">
+                            <h3>@_selectedAncestry.Name</h3>
+                            <FluentButton Appearance="Appearance.Lightweight" OnClick="@(() => _selectedAncestry = null)">
+                                <FluentIcon Value="@(new Icons.Regular.Size20.Dismiss())" />
+                            </FluentButton>
+                        </div>
+                        <p>@_selectedAncestry.Description</p>
+                        @if (_selectedAncestry.Features.Count > 0)
+                        {
+                            <h4>Features</h4>
+                            @foreach (var f in _selectedAncestry.Features)
+                            {
+                                <div class="feature-block">
+                                    <strong>@f.Name</strong>
+                                    <p>@f.Description</p>
+                                </div>
+                            }
+                        }
+                    </FluentCard>
+                </div>
+            }
+        </div>
+
+        @* Classes *@
+        <div class="tab-content" style="display: @(_activeTab == 3 ? null : "none")">
+            <FluentTextField Placeholder="Search by name..." Value="@_classSearch" Immediate ImmediateDelay="200" ValueChanged="@(v => { _classSearch = v; _classItems = FilterClasses().AsQueryable(); StateHasChanged(); })" />
+            <FluentDataGrid Items="@_classItems" GridTemplateColumns="1fr 100px 100px 80px 80px 80px">
+                <PropertyColumn Property="@(c => c.Name)" Title="Name" Sortable="true" />
+                <PropertyColumn Property="@(c => c.Domain1)" Title="Domain 1" Sortable="true" />
+                <PropertyColumn Property="@(c => c.Domain2)" Title="Domain 2" Sortable="true" />
+                <TemplateColumn Title="HP" Align="Align.Center">
+                    <FluentBadge Fill="hp">@context.BaseHealth</FluentBadge>
+                </TemplateColumn>
+                <TemplateColumn Title="Evasion" Align="Align.Center">
+                    <FluentBadge>@context.BaseEvasion</FluentBadge>
+                </TemplateColumn>
+                <TemplateColumn Title="">
+                    <FluentButton Appearance="Appearance.Lightweight" OnClick="@(() => _selectedClass = context)">View</FluentButton>
+                </TemplateColumn>
+            </FluentDataGrid>
+            @if (_selectedClass is not null)
+            {
+                <div class="detail-section">
+                    <FluentCard Class="detail-card">
+                        <div class="detail-header">
+                            <h3>@_selectedClass.Name</h3>
+                            <FluentButton Appearance="Appearance.Lightweight" OnClick="@(() => _selectedClass = null)">
+                                <FluentIcon Value="@(new Icons.Regular.Size20.Dismiss())" />
+                            </FluentButton>
+                        </div>
+                        <div class="detail-stats">
+                            <span><strong>Domains:</strong> @_selectedClass.Domain1, @_selectedClass.Domain2</span>
+                            <span><strong>HP:</strong> @_selectedClass.BaseHealth</span>
+                            <span><strong>Evasion:</strong> @_selectedClass.BaseEvasion</span>
+                        </div>
+                        <p>@_selectedClass.Description</p>
+                        @if (_selectedClass.HopeFeature is not null)
+                        {
+                            <div class="feature-block">
+                                <strong>Hope — @_selectedClass.HopeFeature.Name</strong>
+                                <p>@_selectedClass.HopeFeature.Description</p>
+                            </div>
+                        }
+                        @if (_selectedClass.ClassFeatures.Count > 0)
+                        {
+                            <h4>Class Features</h4>
+                            @foreach (var f in _selectedClass.ClassFeatures)
+                            {
+                                <div class="feature-block">
+                                    <strong>@f.Name</strong>
+                                    <p>@f.Description</p>
+                                </div>
+                            }
+                        }
+                    </FluentCard>
+                </div>
+            }
+        </div>
+
+        @* Armor *@
+        <div class="tab-content" style="display: @(_activeTab == 4 ? null : "none")">
+            <FluentTextField Placeholder="Search by name..." Value="@_armorSearch" Immediate ImmediateDelay="200" ValueChanged="@(v => { _armorSearch = v; _armorItems = FilterArmor().AsQueryable(); StateHasChanged(); })" />
+            <FluentDataGrid Items="@_armorItems" GridTemplateColumns="1fr 80px 100px 120px 80px">
+                <PropertyColumn Property="@(a => a.Name)" Title="Name" Sortable="true" />
+                <TemplateColumn Title="Tier" Sortable="true" Align="Align.Center" SortBy="GridSort<Armor>.ByAscending(a => a.Tier)">
+                    <FluentBadge Fill="tier">T@(context.Tier)</FluentBadge>
+                </TemplateColumn>
+                <TemplateColumn Title="Armor" Align="Align.Center">
+                    <FluentBadge>@context.ArmorScore</FluentBadge>
+                </TemplateColumn>
+                <TemplateColumn Title="Thresholds" Align="Align.Center">
+                    @(context.DamageThresholds.Major)/@(context.DamageThresholds.Severe)
+                </TemplateColumn>
+                <TemplateColumn Title="">
+                    <FluentButton Appearance="Appearance.Lightweight" OnClick="@(() => _selectedArmor = context)">View</FluentButton>
+                </TemplateColumn>
+            </FluentDataGrid>
+            @if (_selectedArmor is not null)
+            {
+                <div class="detail-section">
+                    <FluentCard Class="detail-card">
+                        <div class="detail-header">
+                            <h3>@_selectedArmor.Name</h3>
+                            <FluentButton Appearance="Appearance.Lightweight" OnClick="@(() => _selectedArmor = null)">
+                                <FluentIcon Value="@(new Icons.Regular.Size20.Dismiss())" />
+                            </FluentButton>
+                        </div>
+                        <div class="detail-stats">
+                            <span><strong>Tier:</strong> @_selectedArmor.Tier</span>
+                            <span><strong>Armor Score:</strong> @_selectedArmor.ArmorScore</span>
+                            <span><strong>Major Threshold:</strong> @_selectedArmor.DamageThresholds.Major</span>
+                            <span><strong>Severe Threshold:</strong> @_selectedArmor.DamageThresholds.Severe</span>
+                        </div>
+                        @if (_selectedArmor.Feature is not null)
+                        {
+                            <div class="feature-block">
+                                <strong>@_selectedArmor.Feature.Name</strong>
+                                <p>@_selectedArmor.Feature.Description</p>
+                            </div>
+                        }
+                    </FluentCard>
+                </div>
+            }
+        </div>
+
+        @* Weapons *@
+        <div class="tab-content" style="display: @(_activeTab == 5 ? null : "none")">
+            <FluentTextField Placeholder="Search by name..." Value="@_weaponSearch" Immediate ImmediateDelay="200" ValueChanged="@(v => { _weaponSearch = v; _weaponItems = FilterWeapons().AsQueryable(); StateHasChanged(); })" />
+            <FluentDataGrid Items="@_weaponItems" GridTemplateColumns="1fr 60px 80px 80px 80px 100px 80px">
+                <PropertyColumn Property="@(w => w.Name)" Title="Name" Sortable="true" />
+                <TemplateColumn Title="Tier" Sortable="true" Align="Align.Center" SortBy="GridSort<Weapon>.ByAscending(w => w.Tier)">
+                    <FluentBadge Fill="tier">T@(context.Tier)</FluentBadge>
+                </TemplateColumn>
+                <TemplateColumn Title="Damage" Align="Align.Center">
+                    @(context.Damage.NumberOfDice)d@(context.Damage.NumberOfSides)@(context.Damage.Bonus > 0 ? "+" + context.Damage.Bonus : "")
+                </TemplateColumn>
+                <PropertyColumn Property="@(w => w.Damage.Type)" Title="Type" Sortable="true" />
+                <PropertyColumn Property="@(w => w.Trait)" Title="Trait" Sortable="true" />
+                <PropertyColumn Property="@(w => w.RangeType)" Title="Range" Sortable="true" />
+                <TemplateColumn Title="">
+                    <FluentButton Appearance="Appearance.Lightweight" OnClick="@(() => _selectedWeapon = context)">View</FluentButton>
+                </TemplateColumn>
+            </FluentDataGrid>
+            @if (_selectedWeapon is not null)
+            {
+                <div class="detail-section">
+                    <FluentCard Class="detail-card">
+                        <div class="detail-header">
+                            <h3>@_selectedWeapon.Name</h3>
+                            <FluentButton Appearance="Appearance.Lightweight" OnClick="@(() => _selectedWeapon = null)">
+                                <FluentIcon Value="@(new Icons.Regular.Size20.Dismiss())" />
+                            </FluentButton>
+                        </div>
+                        <div class="detail-stats">
+                            <span><strong>Tier:</strong> @_selectedWeapon.Tier</span>
+                            <span><strong>Damage:</strong> @(_selectedWeapon.Damage.NumberOfDice)d@(_selectedWeapon.Damage.NumberOfSides)@(_selectedWeapon.Damage.Bonus > 0 ? "+" + _selectedWeapon.Damage.Bonus : "") @_selectedWeapon.Damage.Type</span>
+                            <span><strong>Trait:</strong> @_selectedWeapon.Trait</span>
+                            <span><strong>Range:</strong> @_selectedWeapon.RangeType</span>
+                            <span><strong>Burden:</strong> @_selectedWeapon.Burden</span>
+                            <span><strong>Category:</strong> @_selectedWeapon.Category</span>
+                        </div>
+                        @if (_selectedWeapon.Feature is not null)
+                        {
+                            <div class="feature-block">
+                                <strong>@_selectedWeapon.Feature.Name</strong>
+                                <p>@_selectedWeapon.Feature.Description</p>
+                            </div>
+                        }
+                    </FluentCard>
+                </div>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    private bool _loading = true;
+    private int _activeTab = 0;
+
+    private record TabInfo(int Key, string Label);
+    private TabInfo[] _tabs = new[]
+    {
+        new TabInfo(0, "Abilities"),
+        new TabInfo(1, "Items"),
+        new TabInfo(2, "Ancestries"),
+        new TabInfo(3, "Classes"),
+        new TabInfo(4, "Armor"),
+        new TabInfo(5, "Weapons"),
+    };
+
+    private List<Ability> _abilities = new();
+    private List<Item> _items = new();
+    private List<HeritageSummary> _ancestries = new();
+    private List<ClassCardSummary> _classes = new();
+    private List<Armor> _armors = new();
+    private List<Weapon> _weapons = new();
+
+    private IQueryable<Ability> _abilityItems = Enumerable.Empty<Ability>().AsQueryable();
+    private IQueryable<Item> _itemItems = Enumerable.Empty<Item>().AsQueryable();
+    private IQueryable<HeritageSummary> _ancestryItems = Enumerable.Empty<HeritageSummary>().AsQueryable();
+    private IQueryable<ClassCardSummary> _classItems = Enumerable.Empty<ClassCardSummary>().AsQueryable();
+    private IQueryable<Armor> _armorItems = Enumerable.Empty<Armor>().AsQueryable();
+    private IQueryable<Weapon> _weaponItems = Enumerable.Empty<Weapon>().AsQueryable();
+
+    private string _abilitySearch = "";
+    private string _itemSearch = "";
+    private string _ancestrySearch = "";
+    private string _classSearch = "";
+    private string _armorSearch = "";
+    private string _weaponSearch = "";
+
+    private Ability? _selectedAbility;
+    private Item? _selectedItem;
+    private HeritageSummary? _selectedAncestry;
+    private ClassCardSummary? _selectedClass;
+    private Armor? _selectedArmor;
+    private Weapon? _selectedWeapon;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _abilities = AbilityQueries.GetAll();
+        _items = await ItemQueries.GetAllAsync();
+        _ancestries = await HeritageQueries.GetSummariesAsync(HeritageType.Ancestry);
+        _classes = await ClassQueries.GetCardSummariesAsync();
+        _armors = ArmorQueries.GetAll();
+        _weapons = WeaponQueries.GetAll();
+        _abilityItems = FilterAbilities().AsQueryable();
+        _itemItems = FilterItems().AsQueryable();
+        _ancestryItems = FilterAncestries().AsQueryable();
+        _classItems = FilterClasses().AsQueryable();
+        _armorItems = FilterArmor().AsQueryable();
+        _weaponItems = FilterWeapons().AsQueryable();
+        _loading = false;
+    }
+
+    private IEnumerable<Ability> FilterAbilities() =>
+        string.IsNullOrWhiteSpace(_abilitySearch)
+            ? _abilities
+            : _abilities.Where(a => a.Title.Contains(_abilitySearch, StringComparison.OrdinalIgnoreCase));
+
+    private IEnumerable<Item> FilterItems() =>
+        string.IsNullOrWhiteSpace(_itemSearch)
+            ? _items
+            : _items.Where(i => i.Name.Contains(_itemSearch, StringComparison.OrdinalIgnoreCase));
+
+    private IEnumerable<HeritageSummary> FilterAncestries() =>
+        string.IsNullOrWhiteSpace(_ancestrySearch)
+            ? _ancestries
+            : _ancestries.Where(a => a.Name.Contains(_ancestrySearch, StringComparison.OrdinalIgnoreCase));
+
+    private IEnumerable<ClassCardSummary> FilterClasses() =>
+        string.IsNullOrWhiteSpace(_classSearch)
+            ? _classes
+            : _classes.Where(c => c.Name.Contains(_classSearch, StringComparison.OrdinalIgnoreCase));
+
+    private IEnumerable<Armor> FilterArmor() =>
+        string.IsNullOrWhiteSpace(_armorSearch)
+            ? _armors
+            : _armors.Where(a => a.Name.Contains(_armorSearch, StringComparison.OrdinalIgnoreCase));
+
+    private IEnumerable<Weapon> FilterWeapons() =>
+        string.IsNullOrWhiteSpace(_weaponSearch)
+            ? _weapons
+            : _weapons.Where(w => w.Name.Contains(_weaponSearch, StringComparison.OrdinalIgnoreCase));
+}

--- a/Daggerheart-Helper.Shared/Pages/ReferenceCatalog.razor
+++ b/Daggerheart-Helper.Shared/Pages/ReferenceCatalog.razor
@@ -7,16 +7,14 @@
 @inject IWeaponCatalogQueries WeaponQueries
 @inject NavigationManager NavigationManager
 
-<div class="dashboard-container">
-    <div class="dashboard-header">
-        <FluentAnchor Href="/dm-tools" Appearance="Appearance.Hypertext">
-            <FluentIcon Value="@(new Icons.Filled.Size20.ArrowLeft())" /> Back to DM Tools
-        </FluentAnchor>
-        <div class="header-text">
-            <h2>Reference Catalog</h2>
-            <p>Browse all SRD reference data</p>
-        </div>
-    </div>
+<PageHeader Title="Reference Catalog" Subtitle="Browse all SRD reference data">
+    <BackButton>
+        <FluentButton Appearance="Appearance.Stealth"
+                      IconStart="@(new Icons.Filled.Size20.ArrowLeft())"
+                      OnClick="@(() => NavigationManager.NavigateTo("/dm-tools"))"
+                      Title="Back to DM Tools" />
+    </BackButton>
+</PageHeader>
 
     @if (_loading)
     {
@@ -25,25 +23,23 @@
     else
     {
         <FluentStack Orientation="Orientation.Horizontal" Wrap="true" Class="tab-bar">
-            @foreach (var tab in _tabs)
-            {
-                <FluentButton Appearance="@(_activeTab == tab.Key ? Appearance.Accent : Appearance.Neutral)"
-                              OnClick="@(() => _activeTab = tab.Key)">
-                    @tab.Label
-                </FluentButton>
-            }
+            <FluentButton Appearance="@(_activeTabId == "abilities" ? Appearance.Accent : Appearance.Neutral)" OnClick="@(() => _activeTabId = "abilities")">Abilities</FluentButton>
+            <FluentButton Appearance="@(_activeTabId == "items" ? Appearance.Accent : Appearance.Neutral)" OnClick="@(() => _activeTabId = "items")">Items</FluentButton>
+            <FluentButton Appearance="@(_activeTabId == "ancestries" ? Appearance.Accent : Appearance.Neutral)" OnClick="@(() => _activeTabId = "ancestries")">Ancestries</FluentButton>
+            <FluentButton Appearance="@(_activeTabId == "classes" ? Appearance.Accent : Appearance.Neutral)" OnClick="@(() => _activeTabId = "classes")">Classes</FluentButton>
+            <FluentButton Appearance="@(_activeTabId == "armor" ? Appearance.Accent : Appearance.Neutral)" OnClick="@(() => _activeTabId = "armor")">Armor</FluentButton>
+            <FluentButton Appearance="@(_activeTabId == "weapons" ? Appearance.Accent : Appearance.Neutral)" OnClick="@(() => _activeTabId = "weapons")">Weapons</FluentButton>
         </FluentStack>
 
-        @* Abilities *@
-        <div class="tab-content" style="display: @(_activeTab == 0 ? null : "none")">
+        <div class="tab-content" style="display: @(_activeTabId == "abilities" ? null : "none")">
             <FluentTextField Placeholder="Search by name..." Value="@_abilitySearch" Immediate ImmediateDelay="200" ValueChanged="@(v => { _abilitySearch = v; _abilityItems = FilterAbilities().AsQueryable(); StateHasChanged(); })" />
-            <FluentDataGrid Items="@_abilityItems" GridTemplateColumns="1fr 100px 80px 100px 80px 80px">
-                <PropertyColumn Property="@(a => a.Title)" Title="Name" Sortable="true" />
-                <PropertyColumn Property="@(a => a.DomainType)" Title="Domain" Sortable="true" />
+            <FluentDataGrid Items="@_abilityItems" GridTemplateColumns="minmax(150px,1fr) minmax(100px,auto) minmax(60px,auto) minmax(80px,auto) minmax(60px,auto) minmax(60px,auto)">
+                <PropertyColumn Property="@(a => a.Title)" Title="Name" Sortable="true"/>
+                <PropertyColumn Property="@(a => a.DomainType)" Title="Domain" Sortable="true"/>
                 <TemplateColumn Title="Level" Sortable="true" Align="Align.Center" SortBy="GridSort<Ability>.ByAscending(a => a.Level)">
                     <FluentBadge>@context.Level</FluentBadge>
                 </TemplateColumn>
-                <PropertyColumn Property="@(a => a.Type)" Title="Type" Sortable="true" />
+                <PropertyColumn Property="@(a => a.Type)" Title="Type" Sortable="true"/>
                 <TemplateColumn Title="Recall" Align="Align.Center">
                     <FluentBadge Fill="@(context.RecallCost > 0 ? "recall" : "none")">@(context.RecallCost > 0 ? $"{context.RecallCost}" : "—")</FluentBadge>
                 </TemplateColumn>
@@ -73,15 +69,11 @@
             }
         </div>
 
-        @* Items *@
-        <div class="tab-content" style="display: @(_activeTab == 1 ? null : "none")">
+        <div class="tab-content" style="display: @(_activeTabId == "items" ? null : "none")">
             <FluentTextField Placeholder="Search by name..." Value="@_itemSearch" Immediate ImmediateDelay="200" ValueChanged="@(v => { _itemSearch = v; _itemItems = FilterItems().AsQueryable(); StateHasChanged(); })" />
-            <FluentDataGrid Items="@_itemItems" GridTemplateColumns="1fr 2fr 80px">
+            <FluentDataGrid Items="@_itemItems" GridTemplateColumns="minmax(150px,1fr) minmax(200px,2fr)" MultiLine="true">
                 <PropertyColumn Property="@(i => i.Name)" Title="Name" Sortable="true" />
                 <PropertyColumn Property="@(i => i.Description)" Title="Description" />
-                <TemplateColumn Title="">
-                    <FluentButton Appearance="Appearance.Lightweight" OnClick="@(() => _selectedItem = context)">View</FluentButton>
-                </TemplateColumn>
             </FluentDataGrid>
             @if (_selectedItem is not null)
             {
@@ -99,10 +91,9 @@
             }
         </div>
 
-        @* Ancestries *@
-        <div class="tab-content" style="display: @(_activeTab == 2 ? null : "none")">
+        <div class="tab-content" style="display: @(_activeTabId == "ancestries" ? null : "none")">
             <FluentTextField Placeholder="Search by name..." Value="@_ancestrySearch" Immediate ImmediateDelay="200" ValueChanged="@(v => { _ancestrySearch = v; _ancestryItems = FilterAncestries().AsQueryable(); StateHasChanged(); })" />
-            <FluentDataGrid Items="@_ancestryItems" GridTemplateColumns="1fr 100px 80px">
+            <FluentDataGrid Items="@_ancestryItems" GridTemplateColumns="minmax(150px,1fr) minmax(150px,auto) minmax(60px,auto)">
                 <PropertyColumn Property="@(a => a.Name)" Title="Name" Sortable="true" />
                 <TemplateColumn Title="Features">
                     @string.Join(", ", context.Features.Select(f => f.Name))
@@ -138,10 +129,9 @@
             }
         </div>
 
-        @* Classes *@
-        <div class="tab-content" style="display: @(_activeTab == 3 ? null : "none")">
+        <div class="tab-content" style="display: @(_activeTabId == "classes" ? null : "none")">
             <FluentTextField Placeholder="Search by name..." Value="@_classSearch" Immediate ImmediateDelay="200" ValueChanged="@(v => { _classSearch = v; _classItems = FilterClasses().AsQueryable(); StateHasChanged(); })" />
-            <FluentDataGrid Items="@_classItems" GridTemplateColumns="1fr 100px 100px 80px 80px 80px">
+            <FluentDataGrid Items="@_classItems" GridTemplateColumns="minmax(150px,1fr) minmax(80px,auto) minmax(80px,auto) minmax(60px,auto) minmax(60px,auto) minmax(60px,auto)">
                 <PropertyColumn Property="@(c => c.Name)" Title="Name" Sortable="true" />
                 <PropertyColumn Property="@(c => c.Domain1)" Title="Domain 1" Sortable="true" />
                 <PropertyColumn Property="@(c => c.Domain2)" Title="Domain 2" Sortable="true" />
@@ -194,10 +184,9 @@
             }
         </div>
 
-        @* Armor *@
-        <div class="tab-content" style="display: @(_activeTab == 4 ? null : "none")">
+        <div class="tab-content" style="display: @(_activeTabId == "armor" ? null : "none")">
             <FluentTextField Placeholder="Search by name..." Value="@_armorSearch" Immediate ImmediateDelay="200" ValueChanged="@(v => { _armorSearch = v; _armorItems = FilterArmor().AsQueryable(); StateHasChanged(); })" />
-            <FluentDataGrid Items="@_armorItems" GridTemplateColumns="1fr 80px 100px 120px 80px">
+            <FluentDataGrid Items="@_armorItems" GridTemplateColumns="minmax(150px,1fr) minmax(60px,auto) minmax(60px,auto) minmax(80px,auto) minmax(60px,auto)">
                 <PropertyColumn Property="@(a => a.Name)" Title="Name" Sortable="true" />
                 <TemplateColumn Title="Tier" Sortable="true" Align="Align.Center" SortBy="GridSort<Armor>.ByAscending(a => a.Tier)">
                     <FluentBadge Fill="tier">T@(context.Tier)</FluentBadge>
@@ -240,10 +229,9 @@
             }
         </div>
 
-        @* Weapons *@
-        <div class="tab-content" style="display: @(_activeTab == 5 ? null : "none")">
+        <div class="tab-content" style="display: @(_activeTabId == "weapons" ? null : "none")">
             <FluentTextField Placeholder="Search by name..." Value="@_weaponSearch" Immediate ImmediateDelay="200" ValueChanged="@(v => { _weaponSearch = v; _weaponItems = FilterWeapons().AsQueryable(); StateHasChanged(); })" />
-            <FluentDataGrid Items="@_weaponItems" GridTemplateColumns="1fr 60px 80px 80px 80px 100px 80px">
+            <FluentDataGrid Items="@_weaponItems" GridTemplateColumns="minmax(150px,1fr) minmax(50px,auto) minmax(80px,auto) minmax(60px,auto) minmax(80px,auto) minmax(80px,auto) minmax(60px,auto)">
                 <PropertyColumn Property="@(w => w.Name)" Title="Name" Sortable="true" />
                 <TemplateColumn Title="Tier" Sortable="true" Align="Align.Center" SortBy="GridSort<Weapon>.ByAscending(w => w.Tier)">
                     <FluentBadge Fill="tier">T@(context.Tier)</FluentBadge>
@@ -288,22 +276,10 @@
             }
         </div>
     }
-</div>
 
 @code {
     private bool _loading = true;
-    private int _activeTab = 0;
-
-    private record TabInfo(int Key, string Label);
-    private TabInfo[] _tabs = new[]
-    {
-        new TabInfo(0, "Abilities"),
-        new TabInfo(1, "Items"),
-        new TabInfo(2, "Ancestries"),
-        new TabInfo(3, "Classes"),
-        new TabInfo(4, "Armor"),
-        new TabInfo(5, "Weapons"),
-    };
+    private string _activeTabId = "abilities";
 
     private List<Ability> _abilities = new();
     private List<Item> _items = new();

--- a/Daggerheart-Helper.Shared/Pages/ReferenceCatalog.razor.css
+++ b/Daggerheart-Helper.Shared/Pages/ReferenceCatalog.razor.css
@@ -1,0 +1,78 @@
+::deep fluent-data-grid {
+    background: var(--neutral-layer-1);
+    border-radius: 8px;
+}
+
+::deep fluent-data-grid-row {
+    background: var(--neutral-layer-1);
+}
+
+::deep fluent-data-grid-row:hover {
+    background: var(--neutral-layer-3);
+}
+
+::deep fluent-data-grid-cell {
+    padding: 6px 8px;
+}
+
+.tab-bar {
+    margin-bottom: 12px;
+    gap: 4px;
+}
+
+.tab-content {
+    min-height: 200px;
+}
+
+.detail-section {
+    margin-top: 12px;
+}
+
+.detail-card {
+    padding: 16px;
+}
+
+.detail-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+}
+
+.detail-header h3 {
+    margin: 0;
+}
+
+.detail-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-bottom: 12px;
+}
+
+.detail-stats span {
+    background: var(--neutral-layer-3);
+    padding: 4px 10px;
+    border-radius: 6px;
+    font-size: 0.9em;
+}
+
+.feature-block {
+    margin-top: 8px;
+    padding: 8px 12px;
+    background: var(--neutral-layer-2);
+    border-radius: 6px;
+}
+
+.feature-block p {
+    margin: 4px 0 0;
+}
+
+::deep fluent-badge {
+    --badge-fill-hp: color-mix(in srgb, var(--dh-hp) 15%, transparent);
+    --badge-color-hp: var(--dh-hp);
+    --badge-fill-tier: color-mix(in srgb, var(--dh-purple) 15%, transparent);
+    --badge-color-tier: var(--dh-purple);
+    --badge-fill-recall: color-mix(in srgb, var(--dh-positive) 15%, transparent);
+    --badge-color-recall: var(--dh-positive);
+}

--- a/Daggerheart-Helper.Shared/Pages/ReferenceCatalog.razor.css
+++ b/Daggerheart-Helper.Shared/Pages/ReferenceCatalog.razor.css
@@ -1,20 +1,3 @@
-::deep fluent-data-grid {
-    background: var(--neutral-layer-1);
-    border-radius: 8px;
-}
-
-::deep fluent-data-grid-row {
-    background: var(--neutral-layer-1);
-}
-
-::deep fluent-data-grid-row:hover {
-    background: var(--neutral-layer-3);
-}
-
-::deep fluent-data-grid-cell {
-    padding: 6px 8px;
-}
-
 .tab-bar {
     margin-bottom: 12px;
     gap: 4px;
@@ -66,13 +49,4 @@
 
 .feature-block p {
     margin: 4px 0 0;
-}
-
-::deep fluent-badge {
-    --badge-fill-hp: color-mix(in srgb, var(--dh-hp) 15%, transparent);
-    --badge-color-hp: var(--dh-hp);
-    --badge-fill-tier: color-mix(in srgb, var(--dh-purple) 15%, transparent);
-    --badge-color-tier: var(--dh-purple);
-    --badge-fill-recall: color-mix(in srgb, var(--dh-positive) 15%, transparent);
-    --badge-color-recall: var(--dh-positive);
 }

--- a/Daggerheart-Helper.Shared/_Imports.razor
+++ b/Daggerheart-Helper.Shared/_Imports.razor
@@ -8,3 +8,4 @@
 @using Application.Dtos
 @using Application.Services
 @using DaggerheartHelper.Shared.Helpers
+@using DaggerheartHelper.Shared.Components

--- a/Daggerheart-Helper.Shared/wwwroot/app.css
+++ b/Daggerheart-Helper.Shared/wwwroot/app.css
@@ -6,12 +6,25 @@
     --dh-font-heading: 'Outfit', 'Inter', system-ui, sans-serif;
     --dh-font-body: 'Inter', 'Outfit', system-ui, -apple-system, sans-serif;
 
+    /* Domain colors — official Daggerheart */
+    --dh-arcana: #4e345b;
+    --dh-blade: #af231c;
+    --dh-bone: #a4a9a8;
+    --dh-codex: #24395d;
+    --dh-grace: #8d3965;
+    --dh-midnight: #1e201f;
+    --dh-sage: #244e30;
+    --dh-splendor: #b8a342;
+    --dh-valor: #e2680e;
+
     /* Colors */
+    --dh-fear: #160942;
     --dh-purple: #a78bfa;
     --dh-pink: #ec4899;
+    --dh-blue: #10a0b9;
     --dh-hp: #f87171;
     --dh-stress: #fb923c;
-    --dh-hope: #38bdf8;
+    --dh-hope: #e7c74b;
     --dh-positive: #10b981;
     --dh-negative: #ef4444;
     --dh-neutral: #9ca3af;
@@ -29,6 +42,10 @@ body {
     line-height: var(--type-ramp-base-line-height);
     margin: 0;
     min-height: 100dvh;
+    background-image: url('Images/dh-background.jpg');
+    background-size: cover;
+    background-attachment: fixed;
+    background-position: center;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -39,56 +56,7 @@ code {
     color: #c02d76;
 }
 
-/* ===== Layout Components ===== */
-.main {
-    min-height: calc(100dvh - 86px);
-    color: var(--neutral-foreground-rest);
-    align-items: stretch !important;
-    background: transparent;
-}
-
-.body-content {
-    align-self: stretch;
-    min-height: calc(100dvh - 86px) !important;
-    display: flex;
-}
-
-.content {
-    padding: 0.5rem 1.5rem;
-    align-self: stretch !important;
-    width: 100%;
-}
-
-.manage {
-    width: 100dvw;
-}
-
-footer {
-    background: var(--neutral-layer-4);
-    color: var(--neutral-foreground-rest);
-    align-items: center;
-    padding: 10px;
-
-    & a {
-        color: var(--neutral-foreground-rest);
-        text-decoration: none;
-
-        &:focus {
-            outline: 1px dashed;
-            outline-offset: 3px;
-        }
-
-        &:hover {
-            text-decoration: underline;
-        }
-    }
-}
-
 /* ===== Blazor & UI Elements ===== */
-.navmenu-icon {
-    display: none;
-}
-
 .alert {
     border: 1px dashed var(--accent-fill-rest);
     padding: 5px;
@@ -139,7 +107,7 @@ footer {
         transform: rotate(-90deg);
 
         &:last-child {
-            stroke: #1b6ec2;
+            stroke: var(--dh-blue);
             stroke-dasharray: calc(3.141 * var(--blazor-load-percentage, 0%) * 0.8), 500%;
             transition: stroke-dasharray 0.05s ease-in-out;
         }
@@ -158,6 +126,38 @@ footer {
 }
 
 /* ===== Daggerheart Design System ===== */
+
+/* Page — standardiserad sidhuvud för alla sidor */
+.dashboard-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+}
+
+.page-title {
+    font-size: 2.2rem;
+    margin: 0 0 5px 0;
+    background: linear-gradient(135deg, var(--dh-purple) 0%, var(--dh-pink) 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.page-subtitle {
+    margin: 0;
+    color: var(--dh-neutral);
+    font-size: 0.95rem;
+}
+
+/* Page — standardiserad wrapper för alla sidor */
+.dashboard-container {
+    padding: 30px;
+    background: radial-gradient(circle at top, var(--dh-bg-start) 0%, var(--dh-bg-end) 100%);
+    min-height: 90vh;
+    color: #f0f0f5;
+    max-width: 1200px;
+    margin: 0 auto;
+}
 
 /* Page */
 .page-bg {
@@ -243,14 +243,49 @@ footer {
 .text-accent    { color: var(--dh-purple); }
 .text-neutral   { color: var(--dh-neutral); }
 
+/* Domain colors */
+.text-arcana    { color: var(--dh-arcana); }
+.text-blade     { color: var(--dh-blade); }
+.text-bone      { color: var(--dh-bone); }
+.text-codex     { color: var(--dh-codex); }
+.text-grace     { color: var(--dh-grace); }
+.text-midnight  { color: var(--dh-midnight); }
+.text-sage      { color: var(--dh-sage); }
+.text-splendor  { color: var(--dh-splendor); }
+.text-valor     { color: var(--dh-valor); }
+
+.bg-arcana-subtle     { background: color-mix(in srgb, var(--dh-arcana) 20%, transparent); }
+.bg-blade-subtle      { background: color-mix(in srgb, var(--dh-blade) 15%, transparent); }
+.bg-bone-subtle       { background: color-mix(in srgb, var(--dh-bone) 15%, transparent); }
+.bg-codex-subtle      { background: color-mix(in srgb, var(--dh-codex) 20%, transparent); }
+.bg-grace-subtle      { background: color-mix(in srgb, var(--dh-grace) 15%, transparent); }
+.bg-midnight-subtle   { background: color-mix(in srgb, var(--dh-midnight) 25%, transparent); }
+.bg-sage-subtle       { background: color-mix(in srgb, var(--dh-sage) 20%, transparent); }
+.bg-splendor-subtle   { background: color-mix(in srgb, var(--dh-splendor) 15%, transparent); }
+.bg-valor-subtle      { background: color-mix(in srgb, var(--dh-valor) 15%, transparent); }
+
+.border-arcana    { border-color: color-mix(in srgb, var(--dh-arcana) 40%, transparent); }
+.border-blade     { border-color: color-mix(in srgb, var(--dh-blade) 35%, transparent); }
+.border-bone      { border-color: color-mix(in srgb, var(--dh-bone) 35%, transparent); }
+.border-codex     { border-color: color-mix(in srgb, var(--dh-codex) 40%, transparent); }
+.border-grace     { border-color: color-mix(in srgb, var(--dh-grace) 35%, transparent); }
+.border-midnight  { border-color: color-mix(in srgb, var(--dh-midnight) 50%, transparent); }
+.border-sage      { border-color: color-mix(in srgb, var(--dh-sage) 40%, transparent); }
+.border-splendor  { border-color: color-mix(in srgb, var(--dh-splendor) 35%, transparent); }
+.border-valor     { border-color: color-mix(in srgb, var(--dh-valor) 35%, transparent); }
+
 /* Semantic backgrounds & borders */
 .bg-hp-subtle     { background: color-mix(in srgb, var(--dh-hp) 5%, transparent); }
 .bg-stress-subtle { background: color-mix(in srgb, var(--dh-stress) 5%, transparent); }
 .bg-hope-subtle   { background: color-mix(in srgb, var(--dh-hope) 5%, transparent); }
+.bg-evasion-subtle { background: color-mix(in srgb, var(--dh-positive) 5%, transparent); }
+.bg-armor-subtle  { background: color-mix(in srgb, var(--dh-neutral) 5%, transparent); }
 
 .border-hp     { border-color: color-mix(in srgb, var(--dh-hp) 20%, transparent); }
 .border-stress { border-color: color-mix(in srgb, var(--dh-stress) 20%, transparent); }
 .border-hope   { border-color: color-mix(in srgb, var(--dh-hope) 20%, transparent); }
+.border-evasion { border-color: color-mix(in srgb, var(--dh-positive) 20%, transparent); }
+.border-armor  { border-color: color-mix(in srgb, var(--dh-neutral) 20%, transparent); }
 
 /* Cards */
 .card-section {
@@ -267,13 +302,9 @@ footer {
 }
 
 /* Pools */
-.chip-pool {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 10px 8px;
-    border-radius: 8px;
+.pool {
     text-align: center;
+    align-content: center;
 }
 
 .grid-traits {
@@ -301,56 +332,91 @@ footer {
     to { opacity: 1; transform: translateY(0); }
 }
 
-/* ===== Responsive Styles ===== */
-@media (max-width: 600px) {
-    .header-gutters {
-        margin-block: 0.5rem;
-        margin-inline: 1.5rem 3rem !important;
-    }
+/* ===== FluentUI Component Overrides ===== */
 
-    .main {
-        flex-direction: column !important;
-        row-gap: 0 !important;
-    }
+/* FluentBadge — global fill variables, alla fill-värden från alla sidor */
+fluent-badge {
+    font-size: 0.75rem;
+    font-weight: 600;
 
-    nav.sitenav {
-        width: 100%;
-        height: 100%;
-    }
+    /* Adversary role badges */
+    --badge-fill-solo: color-mix(in srgb, var(--dh-hp) 15%, transparent);
+    --badge-color-solo: var(--dh-hp);
+    --badge-fill-bruiser: color-mix(in srgb, var(--dh-stress) 15%, transparent);
+    --badge-color-bruiser: var(--dh-stress);
+    --badge-fill-horde: color-mix(in srgb, #eab308 15%, transparent);
+    --badge-color-horde: #eab308;
+    --badge-fill-leader: color-mix(in srgb, var(--dh-purple) 15%, transparent);
+    --badge-color-leader: var(--dh-purple);
+    --badge-fill-minion: color-mix(in srgb, var(--dh-neutral) 15%, transparent);
+    --badge-color-minion: var(--dh-neutral);
+    --badge-fill-ranged: color-mix(in srgb, var(--dh-positive) 15%, transparent);
+    --badge-color-ranged: var(--dh-positive);
+    --badge-fill-skulk: color-mix(in srgb, var(--dh-blue) 15%, transparent);
+    --badge-color-skulk: var(--dh-blue);
+    --badge-fill-social: color-mix(in srgb, var(--dh-pink) 15%, transparent);
+    --badge-color-social: var(--dh-pink);
+    --badge-fill-standard: color-mix(in srgb, #14b8a6 15%, transparent);
+    --badge-color-standard: #14b8a6;
+    --badge-fill-support: color-mix(in srgb, #06b6d4 15%, transparent);
+    --badge-color-support: #06b6d4;
 
-    #main-menu {
-        width: 100% !important;
+    /* Adversary stat badges */
+    --badge-fill-tier: color-mix(in srgb, var(--dh-purple) 15%, transparent);
+    --badge-color-tier: var(--dh-purple);
+    --badge-fill-difficulty: color-mix(in srgb, var(--dh-negative) 15%, transparent);
+    --badge-color-difficulty: var(--dh-negative);
+    --badge-fill-thresholds: color-mix(in srgb, var(--dh-purple) 15%, transparent);
+    --badge-color-thresholds: var(--dh-purple);
+    --badge-fill-hp: color-mix(in srgb, var(--dh-hp) 15%, transparent);
+    --badge-color-hp: var(--dh-hp);
+    --badge-fill-hope: color-mix(in srgb, var(--dh-hope) 15%, transparent);
+    --badge-color-hope: var(--dh-hope);
+    --badge-fill-stress: color-mix(in srgb, var(--dh-stress) 15%, transparent);
+    --badge-color-stress: var(--dh-stress);
+    --badge-fill-atk: color-mix(in srgb, var(--dh-stress) 15%, transparent);
+    --badge-color-atk: var(--dh-stress);
+    --badge-fill-attack: color-mix(in srgb, var(--dh-negative) 15%, transparent);
+    --badge-color-attack: var(--dh-negative);
+    --badge-fill-exp: color-mix(in srgb, var(--dh-blue) 15%, transparent);
+    --badge-color-exp: var(--dh-blue);
+    --badge-fill-evasion: color-mix(in srgb, var(--dh-positive) 15%, transparent);
+    --badge-color-evasion: var(--dh-positive);
+    --badge-fill-recall: color-mix(in srgb, var(--dh-positive) 15%, transparent);
+    --badge-color-recall: var(--dh-positive);
+    --badge-fill-armor: color-mix(in srgb, var(--dh-neutral) 15%, transparent);
+    --badge-color-armor: var(--dh-neutral);
 
-        & > div:first-child:is(.expander) {
-            display: none;
-        }
-    }
-
-    .navmenu {
-        width: 100%;
-    }
-
-    #navmenu-toggle {
-        appearance: none;
-
-        & ~ nav {
-            display: none;
-        }
-
-        &:checked ~ nav {
-            display: block;
-        }
-    }
-
-    .navmenu-icon {
-        cursor: pointer;
-        z-index: 10;
-        display: block;
-        position: absolute;
-        top: 15px;
-        inset-inline-end: 20px;
-        width: 20px;
-        height: 20px;
-        border: none;
-    }
+    /* Character Creator badges */
+    --badge-fill-class: color-mix(in srgb, var(--dh-purple) 20%, transparent);
+    --badge-color-class: var(--dh-purple);
+    --badge-fill-subclass: color-mix(in srgb, var(--dh-purple) 20%, transparent);
+    --badge-color-subclass: var(--dh-purple);
+    --badge-fill-ancestry: color-mix(in srgb, var(--dh-positive) 20%, transparent);
+    --badge-color-ancestry: var(--dh-positive);
+    --badge-fill-community: color-mix(in srgb, var(--dh-positive) 20%, transparent);
+    --badge-color-community: var(--dh-positive);
+    --badge-fill-name: color-mix(in srgb, var(--dh-hope) 20%, transparent);
+    --badge-color-name: var(--dh-hope);
 }
+
+/* FluentDataGrid — global grid-utseende */
+fluent-data-grid {
+    background: var(--neutral-layer-1);
+    border-radius: 8px;
+}
+
+fluent-data-grid-row {
+    background: var(--neutral-layer-1);
+}
+
+fluent-data-grid-row:hover {
+    background: var(--neutral-layer-3);
+}
+
+fluent-data-grid-cell {
+    padding: 6px 8px;
+}
+
+/* ===== Responsive Styles ===== */
+/* Responsiv layout hanteras av FluentMainLayout/FluentNavMenu (Collapsible) */

--- a/Daggerheart-Helper.Web/Program.cs
+++ b/Daggerheart-Helper.Web/Program.cs
@@ -31,6 +31,7 @@ var srdPath = Path.IsPathRooted(srdJsonPath)
     ? srdJsonPath
     : Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, srdJsonPath));
 await Seed.SrdData(app.Services, srdPath);
+await Seed.SampleCharacter(app.Services);
 
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())

--- a/Infrastructure/Persistence/Seed.cs
+++ b/Infrastructure/Persistence/Seed.cs
@@ -1,4 +1,6 @@
+using Application.Services;
 using Core.Entities;
+using Core.ValueObjects;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -180,6 +182,60 @@ public class Seed
             logger.LogError(ex, "Failed to seed SRD data.");
             throw new InvalidOperationException("Failed to seed SRD data. See inner exception for details.", ex);
         }
+    }
+
+    public static async Task SampleCharacter(IServiceProvider services)
+    {
+        await using var scope = services.CreateAsyncScope();
+        var service = scope.ServiceProvider.GetRequiredService<ICharacterService>();
+        var context = scope.ServiceProvider.GetRequiredService<DaggerheartDbContext>();
+
+        if (await service.GetAllAsync() is { Count: > 0 })
+            return;
+
+        var itemNames = new[] { "Torch", "50 ft rope", "Basic supplies", "Minor Health Potion" };
+        var catalogItems = await context.Items
+            .Where(i => itemNames.Contains(i.Name))
+            .ToListAsync();
+        var inventoryItems = itemNames
+            .Select(name => catalogItems.FirstOrDefault(i => i.Name == name) ?? new Item { Name = name, Description = "" })
+            .ToList();
+
+        var character = new Character
+        {
+            Name = "Borin Ironhide",
+            Pronouns = "he/him",
+            Level = 1,
+            GameClassId = Guid.Parse("D17B68ED-FBBA-4F49-8C8D-5D372871593A"),
+            SubclassId = Guid.Parse("8847BD64-62C5-45C9-9FE3-EAEBA6CF7DD1"),
+            AncestryId = Guid.Parse("C3C7D875-B717-437C-88CD-77D049452FFB"),
+            CommunityId = Guid.Parse("1A996A6E-1381-4384-B370-436FEA5EF74E"),
+            EquippedArmorId = Guid.Parse("748526B9-AF83-4C61-B864-91376AF6791A"),
+            PrimaryWeaponId = Guid.Parse("DB5D5C9C-2B28-4C36-A536-C4DCEB59B747"),
+            Traits = new TraitScores(Agility: 1, Strength: 2, Finesse: -1, Instinct: 0, Presence: 0, Knowledge: 1),
+            DamageThresholds = new DamageThresholds(Major: 5, Severe: 3),
+            Evasion = 10,
+            HitPoints = new ResourcePool(7, 7),
+            Stress = new ResourcePool(0, 6),
+            Hope = new ResourcePool(2, 6),
+            ArmorSlots = new ResourcePool(4, 4),
+            GoldHandfuls = 1,
+            Experiences = new List<string> { "Survived the Goblin Wars", "Guardian of the Mountain Pass" },
+            BackgroundAnswers = new List<string>
+            {
+                "Where were you born?", "The Ironforge Mountains",
+                "Why did you become an adventurer?", "To protect my homeland from the darkness",
+                "What was your childhood like?", "Harsh but honorable, trained in the Forgehold garrison"
+            },
+            Inventory = inventoryItems,
+            CharacterAbilities = new List<CharacterAbility>
+            {
+                new() { AbilityId = Guid.Parse("C017284D-B04D-4C0B-90EA-95C31C869F63"), IsVaulted = false },
+                new() { AbilityId = Guid.Parse("BA159592-DFF9-4A48-8D3A-C2BB25A7B12B"), IsVaulted = false },
+            },
+        };
+
+        await service.SaveAsync(character);
     }
 
     public static async Task EnsureConcurrencyTriggersAsync(DaggerheartDbContext context)

--- a/Infrastructure/Services/CharacterService.cs
+++ b/Infrastructure/Services/CharacterService.cs
@@ -31,6 +31,9 @@ public sealed class CharacterService(IDbContextFactory<DaggerheartDbContext> fac
         return await context.Characters
             .AsNoTracking()
             .Include(c => c.GameClass)
+            .ThenInclude(c => c.HopeFeature)
+            .Include(c => c.GameClass)
+            .ThenInclude(c => c.ClassFeatures)
             .Include(c => c.Subclass)
             .Include(c => c.Ancestry)
             .Include(c => c.Community)


### PR DESCRIPTION
## Reference Catalog
- Manual tabs (FluentButtons + display:none) istället för FluentTabs
- GridTemplateColumns med minmax för responsiva kolumner
- Officiella domänfärger från Daggerheart Card Creator

## Styling & Refactoring
- PageHeader-komponent (Title, Subtitle, BackButton, ChildContent)
- CardHeader-komponent för character cards
- Konsekvent sidstruktur med dashboard-container i MainLayout
- --dh-purple → --dh-fear, --dh-hope → guld
- CSS-konsolidering: badge/grid/header-regler flyttade till app.css
- CharacterSheet: FluentGrid + FluentStack genomgående
- Damage thresholds i CharacterSheet
- BackButton-konsistens (samma över alla sidor)
- SampleCharacter seed-fix (items med descriptions från katalog)
- ClassFeatures inkluderade i CharacterService